### PR TITLE
Add worktree management, workspace creation, and standardize nomenclature

### DIFF
--- a/.geno-agents
+++ b/.geno-agents
@@ -1,5 +1,7 @@
 role: geno-dev
-description: Developer utilities — task execution, commit rewriting
+description: Developer utilities — task execution, commit rewriting, worktree management, workspace creation
 capabilities:
   - dev-tools
   - git-history
+  - git-worktrees
+  - workspaces

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,67 @@
+# geno-dev — developer utilities skillset
+
+Developer and infrastructure skills for Claude Code: task execution from lab notes, git commit history rewriting, worktree management, and workspace creation.
+
+## Skills
+
+| Skill name | Sub-skillset | Skill | Slash command |
+|-----------|-------------|-------|---------------|
+| `geno-dev` | — | — | — (umbrella) |
+| `geno-dev-tasks-start` | tasks | start | `/gt-dev-tasks-start` |
+| `geno-dev-commits-rewrite` | commits | rewrite | `/gt-dev-commits-rewrite` |
+| `geno-dev-worktrees-manage` | worktrees | manage | `/gt-dev-worktrees-manage` |
+| `geno-dev-workspaces-init` | workspaces | init | `/gt-dev-workspaces-init` |
+
+## Compliance
+
+This repo follows geno-ecosystem conventions. All contributors and agents must adhere to:
+
+### Nomenclature
+
+Skill names follow: `{skillset}-{sub-skillset}-{skill-slug}`
+
+- **Skillset** = this repo's name: `geno-dev`
+- **Sub-skillset** = always a **pluralized noun** (e.g., `tasks`, `commits`)
+- **Skill slug** = action verb (e.g., `start`, `rewrite`)
+- **Umbrella** = just `geno-dev`
+
+When adding a new skill, pick the sub-skillset group it belongs to (create a new one if needed, must be a pluralized noun), then name the folder `geno-dev-{sub-skillset}-{skill-slug}`.
+
+Full spec: https://42euge.github.io/geno-tools/skillsets/nomenclature/
+
+### Repo structure
+
+Every geno-ecosystem repo must have:
+
+| File | Purpose |
+|------|---------|
+| `CLAUDE.md` | Project instructions for agents (this file) |
+| `package.json` | Skills manifest with name, version, skills map |
+| `.geno-agents` | Agent identity: role, description, capabilities |
+| `skills/geno-{name}/SKILL.md` | Umbrella skill |
+| `README.md` | Human-facing docs: install, commands table, repo tree |
+
+### SKILL.md frontmatter
+
+Every SKILL.md must include:
+
+```yaml
+---
+name: geno-dev-{sub-skillset}-{skill-slug}   # must match folder name
+description: >-
+  What this skill does.
+  Use when user says /gt-dev-{sub-skillset}-{skill-slug}.
+license: MIT
+metadata:
+  author: 42euge
+  version: "0.1.0"
+---
+```
+
+### Adding a new skill
+
+1. Create `skills/geno-dev-{sub-skillset}-{skill}/SKILL.md` with compliant frontmatter
+2. Update the umbrella `skills/geno-dev/SKILL.md` — add the new command to the description and table
+3. Update `README.md` — command table and repo tree
+4. Update `docs/commands.md` — add a section for the new command
+5. Update this file's Skills table

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,10 +7,10 @@ Developer and infrastructure skills for Claude Code: task execution from lab not
 | Skill name | Sub-skillset | Skill | Slash command |
 |-----------|-------------|-------|---------------|
 | `geno-dev` | — | — | — (umbrella) |
-| `geno-dev-tasks-start` | tasks | start | `/gt-dev-tasks-start` |
-| `geno-dev-commits-rewrite` | commits | rewrite | `/gt-dev-commits-rewrite` |
-| `geno-dev-worktrees-manage` | worktrees | manage | `/gt-dev-worktrees-manage` |
-| `geno-dev-workspaces-init` | workspaces | init | `/gt-dev-workspaces-init` |
+| `geno-dev-tasks-start` | tasks | start | `/geno-dev-tasks-start` |
+| `geno-dev-commits-rewrite` | commits | rewrite | `/geno-dev-commits-rewrite` |
+| `geno-dev-worktrees-manage` | worktrees | manage | `/geno-dev-worktrees-manage` |
+| `geno-dev-workspaces-init` | workspaces | init | `/geno-dev-workspaces-init` |
 
 ## Compliance
 
@@ -50,7 +50,7 @@ Every SKILL.md must include:
 name: geno-dev-{sub-skillset}-{skill-slug}   # must match folder name
 description: >-
   What this skill does.
-  Use when user says /gt-dev-{sub-skillset}-{skill-slug}.
+  Use when user says /geno-dev-{sub-skillset}-{skill-slug}.
 license: MIT
 metadata:
   author: 42euge

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # geno-dev
 
-Developer and infrastructure skills for [Claude Code](https://docs.anthropic.com/en/docs/claude-code). Task execution from lab notes and git commit history rewriting.
+Developer and infrastructure skills for [Claude Code](https://docs.anthropic.com/en/docs/claude-code). Task execution from lab notes, git commit history rewriting, worktree management, and workspace creation.
 
 ## Install
 
@@ -12,8 +12,10 @@ npx skills add 42euge/geno-dev
 
 | Command | Description |
 |---|---|
-| `/gt-dev-task-start [description]` | Pick up a task from lab notes, assess scope, plan if needed, execute, and mark done |
-| `/gt-dev-commit-rewrite` | Rewrite git commit history into a clean narrative (backup branch + soft reset + restage) |
+| `/gt-dev-tasks-start [description]` | Pick up a task from lab notes, assess scope, plan if needed, execute, and mark done |
+| `/gt-dev-commits-rewrite` | Rewrite git commit history into a clean narrative (backup branch + soft reset + restage) |
+| `/gt-dev-worktrees-manage [list\|create\|switch\|prune]` | Manage git worktrees — list, create, switch, and prune |
+| `/gt-dev-workspaces-init [config\|list\|<text>]` | Create development workspaces from issues, tickets, repos, or ideas |
 
 ## Repository structure
 
@@ -24,9 +26,13 @@ geno-dev/
 ├── skills/
 │   ├── geno-dev/         # umbrella skill
 │   │   └── SKILL.md
-│   ├── geno-dev-commit-rewrite/
+│   ├── geno-dev-commits-rewrite/
 │   │   └── SKILL.md
-│   └── geno-dev-task-start/
+│   ├── geno-dev-tasks-start/
+│   │   └── SKILL.md
+│   ├── geno-dev-workspaces-init/
+│   │   └── SKILL.md
+│   └── geno-dev-worktrees-manage/
 │       └── SKILL.md
 └── config/defaults/
     └── colab.json

--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ npx skills add 42euge/geno-dev
 
 | Command | Description |
 |---|---|
-| `/gt-dev-tasks-start [description]` | Pick up a task from lab notes, assess scope, plan if needed, execute, and mark done |
-| `/gt-dev-commits-rewrite` | Rewrite git commit history into a clean narrative (backup branch + soft reset + restage) |
-| `/gt-dev-worktrees-manage [list\|create\|switch\|prune]` | Manage git worktrees — list, create, switch, and prune |
-| `/gt-dev-workspaces-init [config\|list\|<text>]` | Create development workspaces from issues, tickets, repos, or ideas |
+| `/geno-dev-tasks-start [description]` | Pick up a task from lab notes, assess scope, plan if needed, execute, and mark done |
+| `/geno-dev-commits-rewrite` | Rewrite git commit history into a clean narrative (backup branch + soft reset + restage) |
+| `/geno-dev-worktrees-manage [list\|create\|switch\|prune]` | Manage git worktrees — list, create, switch, and prune |
+| `/geno-dev-workspaces-init [config\|list\|<text>]` | Create development workspaces from issues, tickets, repos, or ideas |
 
 ## Repository structure
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -4,7 +4,7 @@
 
 **`/geno-dev-tasks-start [description]`**
 
-Pick up a task from the project's `geno-tools/labnotes/tasks.md` and start working on it.
+Pick up a task from geno-notes and start working on it.
 
 ### Input
 
@@ -20,7 +20,7 @@ The user optionally provides a task description or number. If empty, shows the t
 6. **Complete** — marks done in `tasks.md`, summarizes work, suggests next task
 
 !!! tip
-    If `geno-tools/labnotes/` doesn't exist, the skill will prompt you to run `/geno-notes create` first.
+    If no geno-notes scope exists, the skill will prompt you to run `geno-notes init --project` first.
 
 ---
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -2,7 +2,7 @@
 
 ## Start Task
 
-**`/gt-dev-tasks-start [description]`**
+**`/geno-dev-tasks-start [description]`**
 
 Pick up a task from the project's `geno-tools/labnotes/tasks.md` and start working on it.
 
@@ -20,13 +20,13 @@ The user optionally provides a task description or number. If empty, shows the t
 6. **Complete** — marks done in `tasks.md`, summarizes work, suggests next task
 
 !!! tip
-    If `geno-tools/labnotes/` doesn't exist, the skill will prompt you to run `/gt-lab-notes create` first.
+    If `geno-tools/labnotes/` doesn't exist, the skill will prompt you to run `/geno-notes create` first.
 
 ---
 
 ## Rewrite Commit History
 
-**`/gt-dev-commits-rewrite [branch] [--onto <base>]`**
+**`/geno-dev-commits-rewrite [branch] [--onto <base>]`**
 
 Rewrite git commit history so it tells a clear, logical narrative — as if the work was done in clean, intentional steps from the start.
 
@@ -58,9 +58,9 @@ Rewrite git commit history so it tells a clear, logical narrative — as if the 
 
 ## Manage Worktrees
 
-**`/gt-dev-worktrees-manage [list|create|switch|prune] [args...]`**
+**`/geno-dev-worktrees-manage [list|create|switch|prune] [args...]`**
 
-Manage git worktrees for the current repository. Workspace-aware — if you're inside a workspace created by `/gt-dev-workspaces-init`, worktrees are placed at `<workspace>/.geno/worktrees/<repo>/<branch>/`. Otherwise, inline at `<repo>/.geno/worktrees/<branch>/`.
+Manage git worktrees for the current repository. Workspace-aware — if you're inside a workspace created by `/geno-dev-workspaces-init`, worktrees are placed at `<workspace>/.geno/worktrees/<repo>/<branch>/`. Otherwise, inline at `<repo>/.geno/worktrees/<branch>/`.
 
 ### Subcommands
 
@@ -82,7 +82,7 @@ This skill never edits a project's `.gitignore`, `CLAUDE.md`, or any tracked fil
 
 ## Create Workspace
 
-**`/gt-dev-workspaces-init [config|list|<freeform text>]`**
+**`/geno-dev-workspaces-init [config|list|<freeform text>]`**
 
 Create isolated development workspaces by cloning repos into color-coded folders. Accepts freeform text — the skill infers whether it's a GitHub issue, JIRA ticket, repo names, or a feature idea.
 
@@ -114,4 +114,4 @@ Workspace settings at `~/.geno/config.yaml` (auto-created on first use):
 `list` scans all configured color folders for workspaces. Shows metadata from `.geno/workspace.yaml`, tags legacy `*-WS/` dirs and unmanaged `*-ws/` dirs.
 
 !!! tip
-    Workspaces and worktrees work together: create a workspace with `/gt-dev-workspaces-init`, then use `/gt-dev-worktrees-manage` inside it for branch-level isolation.
+    Workspaces and worktrees work together: create a workspace with `/geno-dev-workspaces-init`, then use `/geno-dev-worktrees-manage` inside it for branch-level isolation.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,0 +1,117 @@
+# Commands
+
+## Start Task
+
+**`/gt-dev-tasks-start [description]`**
+
+Pick up a task from the project's `geno-tools/labnotes/tasks.md` and start working on it.
+
+### Input
+
+The user optionally provides a task description or number. If empty, shows the task list and asks which one to start.
+
+### Workflow
+
+1. **Load context** — reads `tasks.md`, `notes.md`, existing plans, and project instructions
+2. **Select the task** — fuzzy-match from arguments or interactive selection from Active/Backlog
+3. **Assess scope** — small tasks skip planning; medium/large tasks enter plan mode
+4. **Plan** (if needed) — enters plan mode, explores codebase, saves plan to `plans/<task-slug>.md`
+5. **Execute** — works through the task, logging milestones to `notes.md`
+6. **Complete** — marks done in `tasks.md`, summarizes work, suggests next task
+
+!!! tip
+    If `geno-tools/labnotes/` doesn't exist, the skill will prompt you to run `/gt-lab-notes create` first.
+
+---
+
+## Rewrite Commit History
+
+**`/gt-dev-commits-rewrite [branch] [--onto <base>]`**
+
+Rewrite git commit history so it tells a clear, logical narrative — as if the work was done in clean, intentional steps from the start.
+
+### Input
+
+- A branch name (default: current branch)
+- `--onto <base>` to specify the base branch (default: auto-detect merge-base with main/master)
+
+### Workflow
+
+1. **Analyze** — inspects commit log, status, and diffs
+2. **Understand** — reads diffs and lab notes to identify the logical narrative
+3. **Plan** — presents proposed commits to the user for approval
+4. **Execute** — creates backup branch, soft resets, restages files into clean commits
+5. **Verify** — confirms no content lost (`git diff backup-before-rewrite` should be empty)
+6. **Clean up** — optionally deletes backup branch
+
+!!! warning
+    Always creates a `backup-before-rewrite` branch before modifying history. Force push with `--force-with-lease` only after user confirmation.
+
+### Guidelines for good narrative commits
+
+- Each commit should be a single logical unit that makes sense on its own
+- Build on each other in natural progression: scaffold → core → implementation → polish
+- 3–8 commits is usually the sweet spot
+- Explain the "why", not just the "what"
+
+---
+
+## Manage Worktrees
+
+**`/gt-dev-worktrees-manage [list|create|switch|prune] [args...]`**
+
+Manage git worktrees for the current repository. Workspace-aware — if you're inside a workspace created by `/gt-dev-workspaces-init`, worktrees are placed at `<workspace>/.geno/worktrees/<repo>/<branch>/`. Otherwise, inline at `<repo>/.geno/worktrees/<branch>/`.
+
+### Subcommands
+
+- **list** (default) — show all worktrees with branch, status, and category tags
+- **create `<branch>` `[--from <base>]`** — create a new worktree (uses workspace if available, otherwise inline)
+- **switch `<name>`** — find a worktree and print navigation instructions
+- **prune `[--dry-run]`** — remove stale/merged worktrees with interactive confirmation
+
+### Safety
+
+The skill automatically detects and protects:
+
+- **Claude Code worktrees** (`.claude/worktrees/`) — never modified or removed
+- **geno-tools meta-harness worktrees** (`~/.geno/`) — warned before any action
+
+This skill never edits a project's `.gitignore`, `CLAUDE.md`, or any tracked files.
+
+---
+
+## Create Workspace
+
+**`/gt-dev-workspaces-init [config|list|<freeform text>]`**
+
+Create isolated development workspaces by cloning repos into color-coded folders. Accepts freeform text — the skill infers whether it's a GitHub issue, JIRA ticket, repo names, or a feature idea.
+
+### Input modes (inferred from freeform text)
+
+- **GitHub issue** — input contains a `github.com` URL → fetches issue, clones the repo
+- **JIRA ticket** — input matches `[A-Z]+-\d+` → uses as naming label, prompts for repos
+- **Repos** — input looks like repo names or URLs → clones them
+- **Idea** — anything else → AI scans `.geno-agents` files and suggests relevant repos
+
+### Naming
+
+| Source | Format | Example |
+|---|---|---|
+| GitHub issue | `GH-{repo}-{n}-{slug}-ws` | `GH-geno-dev-42-fix-auth-token-ws` |
+| JIRA ticket | `{PROJ-N}-{slug}-ws` | `PROJ-1234-migrate-db-schema-ws` |
+| Repos / Idea | `{slug}-ws` | `voice-coding-assist-ws` |
+
+### Config
+
+Workspace settings at `~/.geno/config.yaml` (auto-created on first use):
+
+- `config` — view current settings
+- `config default <color>` — set default color folder
+- `config add <color>` — add a color folder
+
+### Listing
+
+`list` scans all configured color folders for workspaces. Shows metadata from `.geno/workspace.yaml`, tags legacy `*-WS/` dirs and unmanaged `*-ws/` dirs.
+
+!!! tip
+    Workspaces and worktrees work together: create a workspace with `/gt-dev-workspaces-init`, then use `/gt-dev-worktrees-manage` inside it for branch-level isolation.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,68 @@
+# geno-dev
+
+Developer and infrastructure skills for [Claude Code](https://docs.anthropic.com/en/docs/claude-code). Task execution from lab notes, git commit history rewriting, worktree management, and workspace creation.
+
+Part of the [geno-tools](https://42euge.github.io/geno-tools) ecosystem.
+
+<div class="feature-grid" markdown>
+
+<div class="feature-card" markdown>
+<span class="card-icon">:material-clipboard-check:</span>
+
+### Task execution
+
+Pick up tasks from lab notes, assess scope, plan if needed, execute, and mark done — all from a single slash command.
+
+[See command :material-arrow-right:](commands.md#start-task)
+</div>
+
+<div class="feature-card" markdown>
+<span class="card-icon">:material-source-branch:</span>
+
+### Commit rewriting
+
+Rewrite messy git history into a clean narrative — backup, soft reset, restage in logical chapters.
+
+[See command :material-arrow-right:](commands.md#rewrite-commit-history)
+</div>
+
+<div class="feature-card" markdown>
+<span class="card-icon">:material-git:</span>
+
+### Worktree management
+
+Manage git worktrees — create for feature branches, list with status, and prune stale ones. Automatically protects Claude Code and geno-tools worktrees.
+
+[See command :material-arrow-right:](commands.md#manage-worktrees)
+</div>
+
+<div class="feature-card" markdown>
+<span class="card-icon">:material-folder-multiple:</span>
+
+### Workspace creation
+
+Create isolated development workspaces from GitHub issues, JIRA tickets, or feature ideas. Clone repos into color-coded folders with metadata tracking.
+
+[See command :material-arrow-right:](commands.md#create-workspace)
+</div>
+
+</div>
+
+## Install
+
+```bash
+npx skills add 42euge/geno-dev
+```
+
+## Commands
+
+| Command | Description |
+|---|---|
+| `/gt-dev-tasks-start [description]` | Pick up a task from lab notes, assess scope, plan if needed, execute, and mark done |
+| `/gt-dev-commits-rewrite` | Rewrite git commit history into a clean narrative (backup + soft reset + restage) |
+| `/gt-dev-worktrees-manage [list\|create\|switch\|prune]` | Manage git worktrees — list, create, switch, and prune |
+| `/gt-dev-workspaces-init [config\|list\|<text>]` | Create development workspaces from issues, tickets, repos, or ideas |
+
+## Runtime
+
+No venv, no scripts — pure markdown workflows.

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,10 +58,10 @@ npx skills add 42euge/geno-dev
 
 | Command | Description |
 |---|---|
-| `/gt-dev-tasks-start [description]` | Pick up a task from lab notes, assess scope, plan if needed, execute, and mark done |
-| `/gt-dev-commits-rewrite` | Rewrite git commit history into a clean narrative (backup + soft reset + restage) |
-| `/gt-dev-worktrees-manage [list\|create\|switch\|prune]` | Manage git worktrees — list, create, switch, and prune |
-| `/gt-dev-workspaces-init [config\|list\|<text>]` | Create development workspaces from issues, tickets, repos, or ideas |
+| `/geno-dev-tasks-start [description]` | Pick up a task from lab notes, assess scope, plan if needed, execute, and mark done |
+| `/geno-dev-commits-rewrite` | Rewrite git commit history into a clean narrative (backup + soft reset + restage) |
+| `/geno-dev-worktrees-manage [list\|create\|switch\|prune]` | Manage git worktrees — list, create, switch, and prune |
+| `/geno-dev-workspaces-init [config\|list\|<text>]` | Create development workspaces from issues, tickets, repos, or ideas |
 
 ## Runtime
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,71 @@
+site_name: geno-dev
+site_description: Developer utilities for Claude Code — task execution and commit rewriting
+site_url: https://42euge.github.io/geno-dev
+repo_url: https://github.com/42euge/geno-dev
+repo_name: 42euge/geno-dev
+
+theme:
+  name: material
+  custom_dir: docs/overrides
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: custom
+      accent: custom
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: custom
+      accent: custom
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  font:
+    text: Inter
+    code: JetBrains Mono
+  logo: assets/logo.svg
+  favicon: assets/logo.svg
+  icon:
+    repo: fontawesome/brands/github
+  features:
+    - navigation.sections
+    - navigation.top
+    - content.code.copy
+    - content.code.annotate
+    - search.highlight
+    - search.suggest
+    - toc.follow
+    - announce.dismiss
+
+nav:
+  - Overview: index.md
+  - Commands: commands.md
+
+extra_css:
+  - stylesheets/extra.css
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+  - attr_list
+  - md_in_html
+  - def_list
+  - toc:
+      permalink: true
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/42euge
+  generator: false

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "geno-dev",
   "version": "0.1.0",
-  "description": "Developer utilities — task execution, commit rewriting",
+  "description": "Developer utilities — task execution, commit rewriting, worktree management, workspace creation",
   "skills": {
     "geno-dev": "skills/geno-dev"
   },

--- a/skills/geno-dev-commits-rewrite/SKILL.md
+++ b/skills/geno-dev-commits-rewrite/SKILL.md
@@ -35,8 +35,8 @@ Rewrite git commit history so it tells a clear, logical narrative — as if the 
 ### 2. Understand the work
 
 - Read through all the diffs in the commit range (`git diff <base>..HEAD` or full diff from root)
-- Read `geno-tools/labnotes/notes.md` if it exists for context on what was done and in what order
-- Read `geno-tools/labnotes/tasks.md` if it exists to understand the logical units of work
+- Read geno-notes journal if it exists for context on what was done and in what order
+- Read geno-notes tasks if they exist to understand the logical units of work
 - Identify the logical narrative: what are the natural "chapters" of this work?
 
 ### 3. Plan the new history

--- a/skills/geno-dev-commits-rewrite/SKILL.md
+++ b/skills/geno-dev-commits-rewrite/SKILL.md
@@ -2,7 +2,7 @@
 name: geno-dev-commits-rewrite
 description: >-
   Rewrite git commit history into a clean narrative (backup + soft reset + restage).
-  Use when user says /gt-dev-commits-rewrite.
+  Use when user says /geno-dev-commits-rewrite.
 argument-hint: "[branch] [--onto <base>]"
 license: MIT
 metadata:

--- a/skills/geno-dev-commits-rewrite/SKILL.md
+++ b/skills/geno-dev-commits-rewrite/SKILL.md
@@ -1,8 +1,8 @@
 ---
-name: geno-dev-commit-rewrite
+name: geno-dev-commits-rewrite
 description: >-
   Rewrite git commit history into a clean narrative (backup + soft reset + restage).
-  Use when user says /gt-dev-commit-rewrite.
+  Use when user says /gt-dev-commits-rewrite.
 argument-hint: "[branch] [--onto <base>]"
 license: MIT
 metadata:

--- a/skills/geno-dev-tasks-start/SKILL.md
+++ b/skills/geno-dev-tasks-start/SKILL.md
@@ -1,8 +1,8 @@
 ---
-name: geno-dev-task-start
+name: geno-dev-tasks-start
 description: >-
   Pick up a task from lab notes, assess scope, plan if needed, execute, and mark done.
-  Use when user says /gt-dev-task-start.
+  Use when user says /gt-dev-tasks-start.
 argument-hint: "[task description or number]"
 license: MIT
 metadata:

--- a/skills/geno-dev-tasks-start/SKILL.md
+++ b/skills/geno-dev-tasks-start/SKILL.md
@@ -2,7 +2,7 @@
 name: geno-dev-tasks-start
 description: >-
   Pick up a task from lab notes, assess scope, plan if needed, execute, and mark done.
-  Use when user says /gt-dev-tasks-start.
+  Use when user says /geno-dev-tasks-start.
 argument-hint: "[task description or number]"
 license: MIT
 metadata:
@@ -27,7 +27,7 @@ The user optionally provides a task description or number as `$ARGUMENTS`. If em
 - Check `geno-tools/labnotes/plans/` for any existing plans related to the task
 - Read any CLAUDE.md or project instructions for project context
 
-If `geno-tools/labnotes/` doesn't exist, tell the user to run `/gt-lab-notes create` first and stop.
+If `geno-tools/labnotes/` doesn't exist, tell the user to run `/geno-notes create` first and stop.
 
 ### 2. Select the task
 

--- a/skills/geno-dev-tasks-start/SKILL.md
+++ b/skills/geno-dev-tasks-start/SKILL.md
@@ -12,7 +12,7 @@ metadata:
 
 # Start Task
 
-Pick up a task from the project's `geno-tools/labnotes/tasks.md` and start working on it.
+Pick up a task from geno-notes and start working on it.
 
 ## Input
 
@@ -22,12 +22,12 @@ The user optionally provides a task description or number as `$ARGUMENTS`. If em
 
 ### 1. Load context
 
-- Read `geno-tools/labnotes/tasks.md` in the current working directory
-- Read `geno-tools/labnotes/notes.md` for recent context
-- Check `geno-tools/labnotes/plans/` for any existing plans related to the task
+- Read `geno-notes tasks` in the current working directory
+- Read `geno-notes journal` for recent context
+- Check `geno-notes plans/` for any existing plans related to the task
 - Read any CLAUDE.md or project instructions for project context
 
-If `geno-tools/labnotes/` doesn't exist, tell the user to run `/geno-notes create` first and stop.
+If no geno-notes scope exists (neither `./geno/geno-notes/` nor `~/.geno/geno-notes/`), tell the user to run `geno-notes init --project` first and stop.
 
 ### 2. Select the task
 
@@ -51,7 +51,7 @@ Use the `EnterPlanMode` tool to switch into plan mode. While in plan mode:
 - Design an approach and present it to the user
 - Resolve any open questions
 
-Also save the plan to `geno-tools/labnotes/plans/<task-slug>.md` for future reference, with:
+Also save the plan to `geno-notes plans/<task-slug>.md` for future reference, with:
 
 ```markdown
 # Plan: <task description>
@@ -68,7 +68,7 @@ Once the user approves, use `ExitPlanMode` to leave plan mode and proceed to ste
 ### 5. Execute
 
 - Work through the task (or the plan steps if one was created)
-- As you make progress, append timestamped notes to `geno-tools/labnotes/notes.md` at key milestones (not every small step — just meaningful progress points)
+- As you make progress, append timestamped notes to `geno-notes journal` at key milestones (not every small step — just meaningful progress points)
 - If you hit a blocker or need a decision, stop and ask the user
 
 ### 6. Complete

--- a/skills/geno-dev-workspaces-init/SKILL.md
+++ b/skills/geno-dev-workspaces-init/SKILL.md
@@ -1,0 +1,232 @@
+---
+name: geno-dev-workspaces-init
+description: >-
+  Create development workspaces from GitHub issues, JIRA tickets, repo names, or feature ideas.
+  Clone repos into color-coded folders with metadata and agent rules.
+  Use when user says /geno-dev-workspaces-init.
+argument-hint: "[config|list|<freeform text>]"
+license: MIT
+metadata:
+  author: 42euge
+  version: "0.1.0"
+---
+
+# Create Workspace
+
+Create isolated development workspaces by cloning repos into the user's preferred code space. Accepts freeform input — the skill infers whether it's a GitHub issue, JIRA ticket, repo names, or a feature idea.
+
+## Input
+
+`$ARGUMENTS` is either a utility subcommand (`config`, `list`) or freeform text describing what to work on.
+
+## Zero Footprint Policy
+
+This skill never modifies a project's tracked files. All geno artifacts (`.geno/`, `CLAUDE.local.md`) live in the workspace directory, which is outside any repo's working tree.
+
+## Config System
+
+Workspace settings live at `~/.geno/config.yaml`. Auto-created on first use if missing.
+
+```yaml
+workspaces:
+  mode: color                # code space method — determines folder strategy
+  base_path: "~"
+  color:                     # settings for mode: color
+    default: code-purp
+    folders:
+      - code-red
+      - code-blue
+      - code-purp
+      - code-indigo
+```
+
+The `mode` field selects the code space method. Currently supported: `color`. Future modes (e.g., `flat`, `project`, `date`) can be added by defining a new key under `workspaces` with their own settings.
+
+## Naming Convention
+
+Workspace directory names encode the source and context:
+
+| Source | Format | Example |
+|---|---|---|
+| GitHub issue | `GH-{repo}-{number}-{slug}-ws` | `GH-geno-dev-42-fix-auth-token-ws` |
+| JIRA ticket | `{PROJECT-NUMBER}-{slug}-ws` | `PROJ-1234-migrate-db-schema-ws` |
+| Repos / Idea | `{slug}-ws` | `voice-coding-assist-ws` |
+
+Slug rules: AI-generated, 5–15 characters, 3–4 hyphenated words. Must be filesystem-safe (lowercase, hyphens only).
+
+## Workflow
+
+### 1. Load config
+
+- Read `~/.geno/config.yaml`.
+- If the file does not exist, create it with the defaults shown above.
+- Read `mode` to determine the folder strategy.
+- For `color` mode: read `default` folder and `folders` list.
+
+### 2. Parse input and infer intent
+
+If `$ARGUMENTS` starts with `config` or `list`, route to that subcommand (see below) and stop.
+
+If `$ARGUMENTS` is empty, use `AskUserQuestion` to ask "What are you working on?" with a freeform text option.
+
+Otherwise, infer the mode from the freeform text:
+
+1. **Contains a `github.com` URL** (e.g., `https://github.com/42euge/geno-dev/issues/42`)
+   → **GitHub issue mode**. Extract owner, repo name, and issue number from the URL.
+
+2. **Matches `[A-Z]+-\d+` pattern** (e.g., `PROJ-1234`, `TEAM-56`)
+   → **JIRA ticket mode**. The matched string is the ticket ID.
+
+3. **Looks like repo names** (words that match known geno-ecosystem repo names, or `owner/repo` patterns, or GitHub URLs without issue paths)
+   → **Repos mode**. Each word/URL is a repo to clone.
+
+4. **Anything else** (natural language description)
+   → **Idea mode**. Treat the text as a feature description.
+
+5. **Ambiguous** (could be repo names or a description)
+   → Use `AskUserQuestion` to clarify: "Did you mean repos to clone, or a feature description?" with options for each.
+
+### 3. Resolve repos
+
+#### GitHub issue mode
+
+1. Run `gh issue view <url> --json title,body,labels,assignees` to fetch issue details.
+2. The repo from the URL is the primary repo — always included.
+3. Scan the issue body for references to other repos (look for `github.com/42euge/geno-*` URLs or `geno-*` mentions).
+4. If additional repos are found, suggest them via `AskUserQuestion` (multi-select: "Include these related repos?").
+5. Generate the slug from the issue title (3–4 hyphenated words, 5–15 chars).
+6. Workspace name: `GH-{repo}-{number}-{slug}-ws`
+
+#### JIRA ticket mode
+
+1. No API call — the ticket ID is used for naming only.
+2. Since JIRA tickets don't imply a repo, prompt the user to select repos.
+3. Scan the geno-ecosystem repos directory. For each repo, read its `.geno-agents` file to get role, description, and capabilities.
+4. Present repos via `AskUserQuestion` with multi-select. Each option shows the repo name and its description from `.geno-agents`.
+5. Ask for a short description (or use any additional text from `$ARGUMENTS` after the ticket ID) to generate the slug.
+6. Workspace name: `{TICKET-ID}-{slug}-ws`
+
+#### Repos mode
+
+1. For each repo argument:
+   - If it's a full URL → use as-is
+   - If it's `owner/repo` → expand to `https://github.com/{owner}/{repo}`
+   - If it's a bare name → expand to `https://github.com/42euge/{name}`
+2. Validate each with `gh repo view <repo> --json name,url 2>/dev/null`. If validation fails, warn the user and ask to continue or fix.
+3. Generate the slug from the repo names or ask the user for one.
+4. Workspace name: `{slug}-ws`
+
+#### Idea mode
+
+1. Read `.geno-agents` from every repo directory under the geno-ecosystem path:
+   `/Users/euge/Library/Mobile Documents/iCloud~md~obsidian/Documents/Everything/research/kaggle/gemma-4-good-hackathon/geno-ecosystem/repos/`
+   For each, extract: role, description, capabilities.
+2. Also run `gh repo list 42euge --limit 50 --json name,description` to discover repos not in the local ecosystem directory.
+3. Analyze the idea description against repo descriptions and capabilities. Rank by relevance.
+4. Present the top 3–5 suggested repos via `AskUserQuestion` with multi-select. Each option shows the repo name and why it's relevant.
+5. Generate the slug from the idea description.
+6. Workspace name: `{slug}-ws`
+
+### 4. Confirm with user
+
+Use `AskUserQuestion` to present the workspace plan:
+- Workspace name (the generated directory name)
+- Color folder (the default from config, e.g., `~/code-purp/`)
+- Repos to clone (with URLs)
+
+Options:
+- "Create" — proceed
+- "Change color" — show available color folders as options
+- "Change name" — accept freeform text for a custom name
+
+### 5. Create workspace
+
+For `color` mode:
+
+```bash
+# Ensure color folder exists
+mkdir -p ~/<color>/
+
+# Create workspace structure
+mkdir -p ~/<color>/<workspace-name>/.geno
+
+# Clone each repo
+git clone <url-1> ~/<color>/<workspace-name>/<repo-1>
+git clone <url-2> ~/<color>/<workspace-name>/<repo-2>
+```
+
+Write `.geno/workspace.yaml`:
+
+```yaml
+ticket: GH-geno-dev-42     # or PROJ-1234, or null
+slug: fix-auth-token
+status: active
+repos:
+  - url: https://github.com/42euge/geno-dev
+    path: geno-dev
+  - url: https://github.com/42euge/geno-tools
+    path: geno-tools
+color: code-purp
+created: 2026-04-25T12:00:00Z
+source: issue               # issue | repos | idea
+source_ref: https://github.com/42euge/geno-dev/issues/42
+```
+
+Write `CLAUDE.local.md` at the workspace root:
+
+```markdown
+# Workspace: <workspace-name>
+
+<Ticket/description context>
+Repos: <repo-1>, <repo-2>
+
+## Agent Rules
+- Do not commit `.geno/` or `CLAUDE.local.md` in any repo in this workspace.
+- When staging files, always exclude `.geno/` and `CLAUDE.local.md`.
+- Worktrees for repos in this workspace live at `../.geno/worktrees/<repo>/<branch>/`.
+```
+
+### 6. Report
+
+Tell the user:
+- Workspace created at `~/<color>/<workspace-name>/`
+- Repos cloned: list each with its path
+- Next steps: `cd ~/<color>/<workspace-name>/<repo>/` to start working
+- Mention: `/geno-dev-worktrees-manage` is workspace-aware and will put worktrees in `.geno/worktrees/`
+
+---
+
+## Subcommand: config
+
+Manage workspace configuration at `~/.geno/config.yaml`.
+
+- `config` (no args) → display current mode and settings
+- `config mode <mode>` → switch code space method
+- For `color` mode:
+  - `config default <color>` → set the default color folder
+  - `config add <color>` → add a new color to the folders list
+  - `config remove <color>` → remove a color (with `AskUserQuestion` confirmation)
+
+Read the file, modify the relevant field, write it back. Use YAML formatting.
+
+---
+
+## Subcommand: list
+
+List all workspaces across all configured color folders.
+
+1. Read `~/.geno/config.yaml` to get the folders list (for `color` mode).
+2. For each color folder, scan for directories ending in `-ws` or `-WS` (case-insensitive).
+3. For each match:
+   - If `.geno/workspace.yaml` exists → parse metadata (ticket, repos, status, date, source)
+   - If directory ends in `-WS` (uppercase) and no `workspace.yaml` → tag as `[legacy]`
+   - If directory ends in `-ws` (lowercase) and no `workspace.yaml` → tag as `[unmanaged]`
+4. Display as a table:
+
+| Workspace | Color | Ticket | Repos | Status | Created | Tags |
+|---|---|---|---|---|---|---|
+| `GH-geno-dev-42-fix-auth-ws` | code-purp | GH-geno-dev-42 | geno-dev, geno-tools | active | 2026-04-25 | |
+| `geno-dev-WS` | code-purp | — | — | — | — | [legacy] |
+| `lottie-creator-ws` | code-purp | — | — | — | — | [unmanaged] |
+
+Sort: active workspaces first, then by creation date (newest first). Legacy and unmanaged at the end.

--- a/skills/geno-dev-worktrees-manage/SKILL.md
+++ b/skills/geno-dev-worktrees-manage/SKILL.md
@@ -2,7 +2,7 @@
 name: geno-dev-worktrees-manage
 description: >-
   Manage git worktrees — list, create, switch, and prune.
-  Use when user says /gt-dev-worktrees-manage.
+  Use when user says /geno-dev-worktrees-manage.
 argument-hint: "[list|create|switch|prune] [args...]"
 license: MIT
 metadata:
@@ -77,7 +77,7 @@ Show a table of all worktrees:
 
 If in workspace mode, also scan `<workspace>/.geno/worktrees/` for worktrees belonging to other repos in the workspace and show them grouped by repo.
 
-If there are no worktrees beyond the main one, say so and suggest `create` to get started. If no workspace is set up, mention that `/gt-dev-workspaces-init` can create one.
+If there are no worktrees beyond the main one, say so and suggest `create` to get started. If no workspace is set up, mention that `/geno-dev-workspaces-init` can create one.
 
 ---
 

--- a/skills/geno-dev-worktrees-manage/SKILL.md
+++ b/skills/geno-dev-worktrees-manage/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: geno-dev-worktrees-manage
+description: >-
+  Manage git worktrees — list, create, switch, and prune.
+  Use when user says /gt-dev-worktrees-manage.
+argument-hint: "[list|create|switch|prune] [args...]"
+license: MIT
+metadata:
+  author: 42euge
+  version: "0.1.0"
+---
+
+# Manage Worktrees
+
+Manage git worktrees for the current repository — create worktrees for feature branches, see what exists, switch context, and clean up stale ones.
+
+## Input
+
+`$ARGUMENTS` can optionally specify:
+- A subcommand: `list`, `create`, `switch`, `prune` (default: `list`)
+- Subcommand-specific arguments (see each section below)
+
+## Zero Footprint Policy
+
+This skill NEVER modifies a project's tracked files — no `.gitignore` edits, no `CLAUDE.md` changes, no config file additions. All geno artifacts live either:
+- Outside the repo (workspace mode), or
+- Inside `.geno/` within the repo (inline mode), with agent-level rules to avoid committing them.
+
+## Safety: Protected Worktrees
+
+Before ANY operation, run `git worktree list --porcelain` and classify each entry by its path:
+
+1. **Claude Code worktrees** — path contains `/.claude/worktrees/`
+   NEVER modify, remove, or interact with these. They are managed by Claude Code's agent isolation system.
+   In listings, label them `[claude-code]`.
+
+2. **geno-tools meta-harness worktrees** — path starts with `$HOME/.geno/`
+   These are global skillset worktrees managed by geno-tools (e.g. `~/.geno/geno-dev/worktrees/exp-1`). Show in listings labeled `[geno-tools]`. Never prune without explicit user confirmation and a warning that these are managed by geno-tools. Never create worktrees inside `~/.geno/`.
+
+3. **User worktrees** — everything else. Managed normally by this skill.
+
+## Agent Rules
+
+When operating inside a worktree created by this skill (whether workspace or inline mode):
+
+- NEVER `git add` the `.geno/` directory or any of its contents.
+- NEVER stage `CLAUDE.local.md` for commit.
+- When running `git add .` or `git add -A`, always follow up by unstaging: `git reset HEAD .geno/ CLAUDE.local.md 2>/dev/null` before committing.
+- These paths belong to the geno tooling layer, not to the project.
+
+## Workflow
+
+### 1. Detect environment
+
+- Run `git rev-parse --git-dir` to confirm we are in a git repo. If not, tell the user and stop.
+- Run `git worktree list --porcelain` to get structured worktree data.
+- Classify each worktree per the Safety rules above.
+- **Workspace detection**: check if `../.geno/workspace.yaml` exists (current repo is inside a workspace) or if `.geno/workspace.yaml` exists in cwd (cwd IS the workspace root). If found, set workspace mode and record the workspace path.
+
+### 2. Route to subcommand
+
+Parse `$ARGUMENTS` for the subcommand. If none given, default to `list`.
+
+---
+
+### Subcommand: list
+
+Show a table of all worktrees:
+
+| Column | Source |
+|---|---|
+| Path | Shortened with `~` for home directory |
+| Branch | Branch name or `(detached)` |
+| HEAD | Short commit hash |
+| Status | Clean or dirty — run `git -C <path> status --porcelain` |
+| Category | `[user]`, `[claude-code]`, or `[geno-tools]` |
+
+If in workspace mode, also scan `<workspace>/.geno/worktrees/` for worktrees belonging to other repos in the workspace and show them grouped by repo.
+
+If there are no worktrees beyond the main one, say so and suggest `create` to get started. If no workspace is set up, mention that `/gt-dev-workspaces-init` can create one.
+
+---
+
+### Subcommand: create \<branch\> [--from \<base\>]
+
+1. Validate that `<branch>` does not already exist as a worktree.
+2. Determine the base:
+   - If `--from <base>` is given, use that ref.
+   - Otherwise, use HEAD.
+3. Choose the worktree path based on mode:
+   - **Workspace mode** (`../.geno/workspace.yaml` exists): place at `<workspace>/.geno/worktrees/<repo>/<branch>/`
+     - The `<repo>/` prefix groups worktrees by repo in multi-repo workspaces.
+   - **Inline mode** (no workspace): place at `<repo>/.geno/worktrees/<branch>/`
+     - Create `.geno/worktrees/` if it doesn't exist.
+     - Do NOT edit `.gitignore`. Remind the user that `.geno/` should not be committed and that agent rules are active to prevent accidental staging.
+4. Run: `git worktree add <path> -b <branch> <base>`
+   - If the branch already exists (but has no worktree), use `git worktree add <path> <branch>` without `-b`.
+5. Create a `CLAUDE.local.md` in the new worktree with:
+   ```markdown
+   # Worktree: <branch>
+
+   This is a geno-managed worktree. Do not commit `.geno/` or `CLAUDE.local.md`.
+   ```
+6. Report the created path and suggest the user can `cd` into it or use `switch` to get the path later.
+
+---
+
+### Subcommand: switch \<name-or-branch\>
+
+1. Find the worktree matching `<name-or-branch>` (fuzzy match against branch names and directory names from the worktree list).
+2. If the match is a Claude Code worktree, refuse and explain why.
+3. Print the absolute path.
+4. Tell the user: "Run `cd <path>` in your terminal to switch, or start a new Claude Code session in that directory."
+
+Note: Claude Code cannot change the user's shell working directory. This subcommand is informational — it helps the user find and navigate to worktrees.
+
+---
+
+### Subcommand: prune [--dry-run]
+
+1. Identify candidates for removal:
+   - Worktrees whose branch has been merged into main/master
+   - Worktrees whose branch no longer exists on the remote (use `git branch -vv` to check tracking)
+   - Worktrees marked as prunable by git (directory was manually deleted)
+2. Exclude all Claude Code worktrees — never touch.
+3. For geno-tools worktrees, include in the candidate list but add a `[geno-tools]` warning label.
+4. Present the list to the user via `AskUserQuestion`:
+   - Show each candidate with path, branch, and reason for pruning
+   - Options: "Remove all", "Let me pick", "Cancel"
+5. If `--dry-run` was specified or user chose "Cancel", stop and show what would have been removed.
+6. For each confirmed removal:
+   - Run `git worktree remove <path>` (or `git worktree remove --force <path>` if dirty, after user confirms the force)
+   - If the branch was merged, offer to delete it: `git branch -d <branch>`
+7. Run `git worktree prune` to clean up stale administrative files.
+8. Show summary of what was removed.

--- a/skills/geno-dev/SKILL.md
+++ b/skills/geno-dev/SKILL.md
@@ -3,8 +3,8 @@ name: geno-dev
 description: >-
   Developer and infrastructure utilities — task execution from lab notes,
   git commit history rewriting, worktree management, and workspace creation.
-  Use when user says /gt-dev-tasks-start, /gt-dev-commits-rewrite,
-  /gt-dev-worktrees-manage, or /gt-dev-workspaces-init.
+  Use when user says /geno-dev-tasks-start, /geno-dev-commits-rewrite,
+  /geno-dev-worktrees-manage, or /geno-dev-workspaces-init.
 license: MIT
 metadata:
   author: 42euge
@@ -19,10 +19,10 @@ Dev and infrastructure skills for Claude Code. Task execution, git history rewri
 
 | Command | Description |
 |---|---|
-| `/gt-dev-tasks-start [description]` | Pick up a task from lab notes, assess scope, plan if needed, execute, and mark done |
-| `/gt-dev-commits-rewrite` | Rewrite git commit history into a clean narrative (backup + soft reset + restage) |
-| `/gt-dev-worktrees-manage [list\|create\|switch\|prune]` | Manage git worktrees — list, create, switch, and prune |
-| `/gt-dev-workspaces-init [config\|list\|<text>]` | Create development workspaces from issues, tickets, repos, or ideas |
+| `/geno-dev-tasks-start [description]` | Pick up a task from lab notes, assess scope, plan if needed, execute, and mark done |
+| `/geno-dev-commits-rewrite` | Rewrite git commit history into a clean narrative (backup + soft reset + restage) |
+| `/geno-dev-worktrees-manage [list\|create\|switch\|prune]` | Manage git worktrees — list, create, switch, and prune |
+| `/geno-dev-workspaces-init [config\|list\|<text>]` | Create development workspaces from issues, tickets, repos, or ideas |
 
 ## Runtime
 

--- a/skills/geno-dev/SKILL.md
+++ b/skills/geno-dev/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: geno-dev
 description: >-
-  Developer and infrastructure utilities — task execution from lab notes
-  and git commit history rewriting.
-  Use when user says /gt-dev-task-start or /gt-dev-commit-rewrite.
+  Developer and infrastructure utilities — task execution from lab notes,
+  git commit history rewriting, worktree management, and workspace creation.
+  Use when user says /gt-dev-tasks-start, /gt-dev-commits-rewrite,
+  /gt-dev-worktrees-manage, or /gt-dev-workspaces-init.
 license: MIT
 metadata:
   author: 42euge
@@ -12,14 +13,16 @@ metadata:
 
 # geno-dev — Developer Utilities
 
-Dev and infrastructure skills for Claude Code. Task execution and git history rewriting.
+Dev and infrastructure skills for Claude Code. Task execution, git history rewriting, worktree management, and workspace creation.
 
 ## Commands
 
 | Command | Description |
 |---|---|
-| `/gt-dev-task-start [description]` | Pick up a task from lab notes, assess scope, plan if needed, execute, and mark done |
-| `/gt-dev-commit-rewrite` | Rewrite git commit history into a clean narrative (backup + soft reset + restage) |
+| `/gt-dev-tasks-start [description]` | Pick up a task from lab notes, assess scope, plan if needed, execute, and mark done |
+| `/gt-dev-commits-rewrite` | Rewrite git commit history into a clean narrative (backup + soft reset + restage) |
+| `/gt-dev-worktrees-manage [list\|create\|switch\|prune]` | Manage git worktrees — list, create, switch, and prune |
+| `/gt-dev-workspaces-init [config\|list\|<text>]` | Create development workspaces from issues, tickets, repos, or ideas |
 
 ## Runtime
 


### PR DESCRIPTION
## Summary

- **New skill: `geno-dev-worktrees-manage`** — manage git worktrees (list, create, switch, prune) with safety classification that protects Claude Code and geno-tools worktrees. Workspace-aware: detects `.geno/workspace.yaml` and places worktrees accordingly.
- **New skill: `geno-dev-workspaces-init`** — create isolated development workspaces from GitHub issues, JIRA tickets, repo names, or freeform ideas. Clones repos into color-coded folders with structured metadata and agent rules. Configurable via `~/.geno/config.yaml` with extensible `mode` system.
- **Nomenclature standardization** — pluralize sub-skillset names, canonical `geno-dev-*` skill names everywhere (no `gt-` prefix; aliasing handled at geno-tools level).

## Test plan

- [ ] Run `/geno-dev-worktrees-manage list` in a git repo — verify worktree table renders
- [ ] Run `/geno-dev-worktrees-manage create test-branch` — verify worktree created at `.geno/worktrees/test-branch/`
- [ ] Run `/geno-dev-workspaces-init` with a GitHub issue URL — verify workspace created with `GH-{repo}-{n}-{slug}-ws` naming
- [ ] Run `/geno-dev-workspaces-init config` — verify `~/.geno/config.yaml` auto-created
- [ ] Run `/geno-dev-workspaces-init list` — verify existing workspaces and legacy `*-WS/` dirs listed
- [ ] Verify all command tables are consistent across CLAUDE.md, README.md, umbrella SKILL.md, docs/commands.md, docs/index.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)