### PR TITLE
Add sessions-fork skill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # geno-dev — developer utilities skillset
 
-Developer and infrastructure skills for Claude Code: task execution from lab notes, git commit history rewriting, worktree management, and workspace creation.
+Developer and infrastructure skills for Claude Code: task execution from lab notes, git commit history rewriting, worktree management, workspace creation, and session forking.
 
 ## Skills
 
@@ -11,6 +11,7 @@ Developer and infrastructure skills for Claude Code: task execution from lab not
 | `geno-dev-commits-rewrite` | commits | rewrite | `/geno-dev-commits-rewrite` |
 | `geno-dev-worktrees-manage` | worktrees | manage | `/geno-dev-worktrees-manage` |
 | `geno-dev-workspaces-init` | workspaces | init | `/geno-dev-workspaces-init` |
+| `geno-dev-sessions-fork` | sessions | fork | `/geno-dev-sessions-fork` |
 
 ## Compliance
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # geno-dev
 
-Developer and infrastructure skills for [Claude Code](https://docs.anthropic.com/en/docs/claude-code). Task execution from lab notes, git commit history rewriting, worktree management, and workspace creation.
+Developer and infrastructure skills for [Claude Code](https://docs.anthropic.com/en/docs/claude-code). Task execution from lab notes, git commit history rewriting, worktree management, workspace creation, and session forking.
 
 ## Install
 
@@ -16,6 +16,7 @@ npx skills add 42euge/geno-dev
 | `/geno-dev-commits-rewrite` | Rewrite git commit history into a clean narrative (backup branch + soft reset + restage) |
 | `/geno-dev-worktrees-manage [list\|create\|switch\|prune]` | Manage git worktrees — list, create, switch, and prune |
 | `/geno-dev-workspaces-init [config\|list\|<text>]` | Create development workspaces from issues, tickets, repos, or ideas |
+| `/geno-dev-sessions-fork [session]` | Fork a Claude Code session — extract context to continue in a new session |
 
 ## Repository structure
 
@@ -27,6 +28,8 @@ geno-dev/
 │   ├── geno-dev/         # umbrella skill
 │   │   └── SKILL.md
 │   ├── geno-dev-commits-rewrite/
+│   │   └── SKILL.md
+│   ├── geno-dev-sessions-fork/
 │   │   └── SKILL.md
 │   ├── geno-dev-tasks-start/
 │   │   └── SKILL.md

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -80,6 +80,36 @@ This skill never edits a project's `.gitignore`, `CLAUDE.md`, or any tracked fil
 
 ---
 
+## Fork Session
+
+**`/geno-dev-sessions-fork [session] [--output <file>] [--max-messages <N>]`**
+
+Fork a Claude Code session — extract the full context (environment, files touched, conversation history) and produce a structured markdown document for continuing work in a new session.
+
+### Prerequisites
+
+- `geno-mon` must be installed and available on `$PATH`
+
+### Workflow
+
+1. **Discover** — runs `geno-mon list` to show recent sessions
+2. **Select** — uses the user's argument or asks them to pick
+3. **Extract** — runs `geno-mon fork <session>` to produce the context document
+4. **Deliver** — writes to file or displays, with instructions on how to use it
+
+### Options
+
+| Flag | Description |
+|---|---|
+| `<session>` | Session number, partial ID, or JSONL path (default: latest) |
+| `-o <file>` | Write output to a file instead of stdout |
+| `-m <N>` | Maximum user messages to include (default: 50) |
+
+!!! tip
+    The fork output includes environment, files modified/read, commands run, and full conversation history — everything a new session needs to continue where the original left off.
+
+---
+
 ## Create Workspace
 
 **`/geno-dev-workspaces-init [config|list|<freeform text>]`**

--- a/skills/geno-dev-sessions-fork/SKILL.md
+++ b/skills/geno-dev-sessions-fork/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: geno-dev-sessions-fork
+description: >-
+  Fork a Claude Code session — extract its full context and start a new session
+  that continues where the original left off.
+  Use when user says /geno-dev-sessions-fork.
+license: MIT
+metadata:
+  author: 42euge
+  version: "0.1.0"
+---
+
+# geno-dev-sessions-fork
+
+Fork a Claude Code session: extract the full context (environment, files touched, conversation history) and produce a structured markdown document suitable for continuing the work in a new session.
+
+## Usage
+
+```
+/geno-dev-sessions-fork [session] [--output <file>] [--max-messages <N>]
+```
+
+## Prerequisites
+
+- `geno-mon` must be installed and available on `$PATH`
+
+## Workflow
+
+1. **Discover sessions** — run `geno-mon list` to show recent sessions
+2. **Select session** — use the user's argument or ask them to pick one
+3. **Extract context** — run `geno-mon fork <session>` to extract the session context
+4. **Deliver** — write the context to a file (if `--output` given) or display it
+
+### Step 1 — Discover sessions
+
+```bash
+geno-mon list
+```
+
+If the user provided a session argument (number, partial ID, or path), skip the picker and go to step 3.
+
+### Step 2 — Select session
+
+If no session was specified, show the list output and ask the user which session to fork.
+
+### Step 3 — Extract context
+
+```bash
+geno-mon fork <session>                    # display to stdout
+geno-mon fork <session> -o context.md      # write to file
+geno-mon fork <session> -m 20             # limit to last 20 user messages
+```
+
+The fork output is a structured markdown document with these sections:
+
+- **Environment** — working directory, git branch, model
+- **Files Modified** — files the session edited or created
+- **Files Read** — files read but not modified
+- **Commands Run** — unique shell commands executed (last 30, deduplicated)
+- **Conversation History** — user messages with assistant responses and tool usage summaries
+
+### Step 4 — Deliver
+
+- If `--output <file>` was given, confirm the file was written
+- Otherwise, display the context to the user
+- Suggest how to use it: paste into a new Claude Code session prefixed with "Continue the work described in this context"
+
+## Options
+
+| Flag | Description |
+|---|---|
+| `<session>` | Session number, partial ID, or JSONL path (default: latest) |
+| `-o <file>`, `--output <file>` | Write output to a file instead of stdout |
+| `-m <N>`, `--max-messages <N>` | Maximum user messages to include (default: 50) |
+
+## Use cases
+
+- **Session continuation** — pick up where a session left off after it ended or was interrupted
+- **Handoff** — pass session context to a different model or agent configuration
+- **Knowledge transfer** — share what a session accomplished with other agents or team members
+- **Debugging** — extract a full record of what happened in a session for analysis

--- a/skills/geno-dev/SKILL.md
+++ b/skills/geno-dev/SKILL.md
@@ -2,9 +2,10 @@
 name: geno-dev
 description: >-
   Developer and infrastructure utilities — task execution from lab notes,
-  git commit history rewriting, worktree management, and workspace creation.
+  git commit history rewriting, worktree management, workspace creation,
+  and session forking.
   Use when user says /geno-dev-tasks-start, /geno-dev-commits-rewrite,
-  /geno-dev-worktrees-manage, or /geno-dev-workspaces-init.
+  /geno-dev-worktrees-manage, /geno-dev-workspaces-init, or /geno-dev-sessions-fork.
 license: MIT
 metadata:
   author: 42euge
@@ -13,7 +14,7 @@ metadata:
 
 # geno-dev — Developer Utilities
 
-Dev and infrastructure skills for Claude Code. Task execution, git history rewriting, worktree management, and workspace creation.
+Dev and infrastructure skills for Claude Code. Task execution, git history rewriting, worktree management, workspace creation, and session forking.
 
 ## Commands
 
@@ -23,6 +24,7 @@ Dev and infrastructure skills for Claude Code. Task execution, git history rewri
 | `/geno-dev-commits-rewrite` | Rewrite git commit history into a clean narrative (backup + soft reset + restage) |
 | `/geno-dev-worktrees-manage [list\|create\|switch\|prune]` | Manage git worktrees — list, create, switch, and prune |
 | `/geno-dev-workspaces-init [config\|list\|<text>]` | Create development workspaces from issues, tickets, repos, or ideas |
+| `/geno-dev-sessions-fork [session]` | Fork a Claude Code session — extract context to continue in a new session |
 
 ## Runtime
 


### PR DESCRIPTION
## Summary

- Add `geno-dev-sessions-fork` skill that orchestrates `geno-mon fork` to extract session context for continuing work in a new session
- Update umbrella skill, CLAUDE.md, README, and docs with the new command
- Follows nomenclature: sub-skillset `sessions`, skill slug `fork`

Companion to https://github.com/42euge/geno-mon/pull/7 which keeps the `fork` CLI command in geno-mon but removes the fork docs (they now live here).

## Test plan

- [ ] Run `/geno-dev-sessions-fork` and verify it invokes `geno-mon fork`
- [ ] Verify skill is listed in `/geno-dev` umbrella output