### PR TITLE
chore(geno-audit): bring repo into ecosystem compliance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,49 @@
+# geno-dev — developer utilities skillset
+
+Developer and infrastructure skills for coding agents: task execution from lab notes, git commit history rewriting, worktree management, workspace creation, and session forking.
+
+## Skills
+
+| Skill name | Slash command | Description |
+|-----------|---------------|-------------|
+| `geno-dev` | — (umbrella) | Umbrella skill for all geno-dev utilities |
+| `geno-dev-tasks-start` | `/geno-dev-tasks-start` | Pick up a task from lab notes, plan if needed, execute, and mark done |
+| `geno-dev-commits-rewrite` | `/geno-dev-commits-rewrite` | Rewrite git commit history into a clean narrative |
+| `geno-dev-worktrees-manage` | `/geno-dev-worktrees-manage` | Manage git worktrees — list, create, switch, and prune |
+| `geno-dev-workspaces-init` | `/geno-dev-workspaces-init` | Create development workspaces from issues, tickets, repos, or ideas |
+| `geno-dev-sessions-fork` | `/geno-dev-sessions-fork` | Fork a Claude Code session to continue in a new session |
+
+## Repo structure
+
+```
+geno-dev/
+├── package.json          # Skills manifest
+├── .geno-agents          # Agent identity for auto-registration
+├── skills/
+│   ├── geno-dev/         # Umbrella skill
+│   │   └── SKILL.md
+│   ├── geno-dev-commits-rewrite/
+│   │   └── SKILL.md
+│   ├── geno-dev-sessions-fork/
+│   │   └── SKILL.md
+│   ├── geno-dev-tasks-start/
+│   │   └── SKILL.md
+│   ├── geno-dev-workspaces-init/
+│   │   └── SKILL.md
+│   └── geno-dev-worktrees-manage/
+│       └── SKILL.md
+└── config/defaults/
+    └── colab.json
+```
+
+## Compliance
+
+This repo follows geno-ecosystem conventions. Skill names follow: `{skillset}-{sub-skillset}-{skill-slug}`.
+
+- **Skillset** = `geno-dev`
+- **Sub-skillset** = pluralized noun (e.g., `tasks`, `commits`)
+- **Skill slug** = action verb (e.g., `start`, `rewrite`)
+
+## Runtime
+
+No venv, no scripts — pure markdown workflows.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,51 @@
+# geno-dev — developer utilities skillset
+
+@import SKILL.md from skills/geno-dev/SKILL.md
+
+Developer and infrastructure skills for coding agents: task execution from lab notes, git commit history rewriting, worktree management, workspace creation, and session forking.
+
+## Skills
+
+| Skill name | Slash command | Description |
+|-----------|---------------|-------------|
+| `geno-dev` | — (umbrella) | Umbrella skill for all geno-dev utilities |
+| `geno-dev-tasks-start` | `/geno-dev-tasks-start` | Pick up a task from lab notes, plan if needed, execute, and mark done |
+| `geno-dev-commits-rewrite` | `/geno-dev-commits-rewrite` | Rewrite git commit history into a clean narrative |
+| `geno-dev-worktrees-manage` | `/geno-dev-worktrees-manage` | Manage git worktrees — list, create, switch, and prune |
+| `geno-dev-workspaces-init` | `/geno-dev-workspaces-init` | Create development workspaces from issues, tickets, repos, or ideas |
+| `geno-dev-sessions-fork` | `/geno-dev-sessions-fork` | Fork a Claude Code session to continue in a new session |
+
+## Repo structure
+
+```
+geno-dev/
+├── package.json          # Skills manifest
+├── .geno-agents          # Agent identity for auto-registration
+├── skills/
+│   ├── geno-dev/         # Umbrella skill
+│   │   └── SKILL.md
+│   ├── geno-dev-commits-rewrite/
+│   │   └── SKILL.md
+│   ├── geno-dev-sessions-fork/
+│   │   └── SKILL.md
+│   ├── geno-dev-tasks-start/
+│   │   └── SKILL.md
+│   ├── geno-dev-workspaces-init/
+│   │   └── SKILL.md
+│   └── geno-dev-worktrees-manage/
+│       └── SKILL.md
+└── config/defaults/
+    └── colab.json
+```
+
+## Compliance
+
+This repo follows geno-ecosystem conventions. Skill names follow: `{skillset}-{sub-skillset}-{skill-slug}`.
+
+- **Skillset** = `geno-dev`
+- **Sub-skillset** = pluralized noun (e.g., `tasks`, `commits`)
+- **Skill slug** = action verb (e.g., `start`, `rewrite`)
+
+## Runtime
+
+No venv, no scripts — pure markdown workflows.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,58 @@
+# Getting Started
+
+## Prerequisites
+
+- [Claude Code](https://docs.anthropic.com/en/docs/claude-code) installed and configured
+- [npx skills](https://github.com/nichochar/skills) available on your PATH
+- Git installed
+
+## Install
+
+```bash
+npx skills add 42euge/geno-dev
+```
+
+This registers all geno-dev skills with Claude Code (and other supported agents). No venv or runtime dependencies are needed — geno-dev is pure markdown workflows.
+
+## First use
+
+Once installed, the following slash commands are available in any Claude Code session:
+
+| Command | What it does |
+|---|---|
+| `/geno-dev-tasks-start` | Pick up a task from lab notes and execute it |
+| `/geno-dev-commits-rewrite` | Rewrite git history into a clean narrative |
+| `/geno-dev-worktrees-manage` | Manage git worktrees (list, create, switch, prune) |
+| `/geno-dev-workspaces-init` | Create development workspaces from issues, tickets, or ideas |
+| `/geno-dev-sessions-fork` | Fork a session to continue in a new one |
+
+## Quick example
+
+Start a task from your lab notes:
+
+```
+/geno-dev-tasks-start fix the auth token bug
+```
+
+The skill will load your geno-notes tasks, find the matching task, assess its scope, plan if needed, execute, and mark it done.
+
+## Workspace workflow
+
+Create an isolated workspace for a GitHub issue:
+
+```
+/geno-dev-workspaces-init https://github.com/42euge/geno-dev/issues/42
+```
+
+Then use worktree management inside the workspace:
+
+```
+/geno-dev-worktrees-manage create feature/fix-auth
+```
+
+Workspaces and worktrees are designed to work together for branch-level isolation within project-level organization.
+
+## What's next
+
+- See [Commands](commands.md) for detailed usage of each slash command
+- Check [geno-tools docs](https://42euge.github.io/geno-tools) for the broader ecosystem

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,52 +1,16 @@
 # geno-dev
 
-Developer and infrastructure skills for [Claude Code](https://docs.anthropic.com/en/docs/claude-code). Task execution from lab notes, git commit history rewriting, worktree management, and workspace creation.
+Developer and infrastructure skills for [Claude Code](https://docs.anthropic.com/en/docs/claude-code). Task execution from lab notes, git commit history rewriting, worktree management, workspace creation, and session forking.
 
 Part of the [geno-tools](https://42euge.github.io/geno-tools) ecosystem.
 
-<div class="feature-grid" markdown>
+## What's included
 
-<div class="feature-card" markdown>
-<span class="card-icon">:material-clipboard-check:</span>
-
-### Task execution
-
-Pick up tasks from lab notes, assess scope, plan if needed, execute, and mark done — all from a single slash command.
-
-[See command :material-arrow-right:](commands.md#start-task)
-</div>
-
-<div class="feature-card" markdown>
-<span class="card-icon">:material-source-branch:</span>
-
-### Commit rewriting
-
-Rewrite messy git history into a clean narrative — backup, soft reset, restage in logical chapters.
-
-[See command :material-arrow-right:](commands.md#rewrite-commit-history)
-</div>
-
-<div class="feature-card" markdown>
-<span class="card-icon">:material-git:</span>
-
-### Worktree management
-
-Manage git worktrees — create for feature branches, list with status, and prune stale ones. Automatically protects Claude Code and geno-tools worktrees.
-
-[See command :material-arrow-right:](commands.md#manage-worktrees)
-</div>
-
-<div class="feature-card" markdown>
-<span class="card-icon">:material-folder-multiple:</span>
-
-### Workspace creation
-
-Create isolated development workspaces from GitHub issues, JIRA tickets, or feature ideas. Clone repos into color-coded folders with metadata tracking.
-
-[See command :material-arrow-right:](commands.md#create-workspace)
-</div>
-
-</div>
+- **Task execution** -- pick up tasks from lab notes, assess scope, plan if needed, execute, and mark done
+- **Commit rewriting** -- rewrite messy git history into a clean narrative with backup and verification
+- **Worktree management** -- create, list, switch, and prune git worktrees with workspace awareness
+- **Workspace creation** -- create isolated dev workspaces from GitHub issues, JIRA tickets, repos, or ideas
+- **Session forking** -- extract full context from a Claude Code session to continue in a new one
 
 ## Install
 
@@ -60,9 +24,11 @@ npx skills add 42euge/geno-dev
 |---|---|
 | `/geno-dev-tasks-start [description]` | Pick up a task from lab notes, assess scope, plan if needed, execute, and mark done |
 | `/geno-dev-commits-rewrite` | Rewrite git commit history into a clean narrative (backup + soft reset + restage) |
-| `/geno-dev-worktrees-manage [list\|create\|switch\|prune]` | Manage git worktrees — list, create, switch, and prune |
+| `/geno-dev-worktrees-manage [list\|create\|switch\|prune]` | Manage git worktrees -- list, create, switch, and prune |
 | `/geno-dev-workspaces-init [config\|list\|<text>]` | Create development workspaces from issues, tickets, repos, or ideas |
+| `/geno-dev-sessions-fork [session]` | Fork a Claude Code session to continue in a new session |
 
-## Runtime
+## Next steps
 
-No venv, no scripts — pure markdown workflows.
+- [Getting Started](getting-started.md) -- install, prerequisites, first use
+- [Commands](commands.md) -- detailed reference for each slash command

--- a/genotools.yaml
+++ b/genotools.yaml
@@ -1,0 +1,6 @@
+name: geno-dev
+version: "0.1.0"
+description: >-
+  Developer and infrastructure utilities — task execution from lab notes,
+  git commit history rewriting, worktree management, workspace creation,
+  and session forking.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,7 +6,6 @@ repo_name: 42euge/geno-dev
 
 theme:
   name: material
-  custom_dir: docs/overrides
   palette:
     - media: "(prefers-color-scheme: light)"
       scheme: default
@@ -25,8 +24,6 @@ theme:
   font:
     text: Inter
     code: JetBrains Mono
-  logo: assets/logo.svg
-  favicon: assets/logo.svg
   icon:
     repo: fontawesome/brands/github
   features:
@@ -40,11 +37,9 @@ theme:
     - announce.dismiss
 
 nav:
-  - Overview: index.md
+  - Home: index.md
+  - Getting Started: getting-started.md
   - Commands: commands.md
-
-extra_css:
-  - stylesheets/extra.css
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
## Audit Report: geno-dev

Automated compliance audit via `geno-audit`.

### Summary
  PASS: 14    FAIL: 1 fixed    WARN: 3 fixed    INFO: 2 fixed

### Checks

#### .geno Convention
- [x] PASS `.geno/` not tracked by git
- [x] PASS `CLAUDE.local.md` not tracked by git
- [x] PASS Global gitignore includes `.geno/` and `CLAUDE.local.md`

#### Manifest — genotools.yaml
- [x] FIXED `genotools.yaml` did not exist — created with `name`, `version`, `description`

#### SKILL.md (Umbrella)
- [x] PASS `skills/geno-dev/SKILL.md` exists with valid YAML frontmatter
- [x] PASS Frontmatter has `name: geno-dev`
- [x] PASS Frontmatter has non-empty `description`
- [x] PASS Frontmatter has `metadata` with `author` and `version`

#### Agent Instruction Files
- [x] PASS `CLAUDE.md` exists
- [x] FIXED `GEMINI.md` did not exist — created from SKILL.md and repo structure
- [x] FIXED `AGENTS.md` did not exist — created from SKILL.md and repo structure

#### Documentation
- [x] PASS `docs/` directory exists
- [x] PASS `docs/index.md` exists
- [x] FIXED `docs/getting-started.md` did not exist — created with install, prerequisites, first use
- [x] PASS `mkdocs.yml` exists at repo root
- [x] PASS `mkdocs.yml` uses `material` theme
- [x] FIXED `mkdocs.yml` had `custom_dir: docs/overrides` (hero pattern) — removed
- [x] FIXED `mkdocs.yml` referenced non-existent `assets/logo.svg` and `stylesheets/extra.css` — removed
- [x] FIXED `docs/index.md` used feature-card hero layout — simplified to plain summary per convention
- [x] PASS `site_url` and `repo_url` configured

#### Repo Hygiene
- [x] PASS `README.md` exists
- [x] PASS `LICENSE` exists
- [x] PASS Repo directory name matches `geno-*` convention

### Changes

**New files:**
- `genotools.yaml` — ecosystem manifest (Manifest section)
- `GEMINI.md` — Gemini CLI agent instruction file (Agent Instruction Files section)
- `AGENTS.md` — OpenAI Codex agent instruction file (Agent Instruction Files section)
- `docs/getting-started.md` — install and first-use guide (Documentation section)

**Modified files:**
- `mkdocs.yml` — removed `custom_dir: docs/overrides`, removed broken `logo`/`favicon`/`extra_css` refs, added `getting-started.md` to nav, renamed Overview to Home
- `docs/index.md` — replaced feature-card hero with plain summary and nav links

### Remaining items

- `docs/assets/icon.png` does not exist (INFO — optional, generate via `geno-icons`)