### PR TITLE
Add geno-dev-feature-ship skill

### DIFF
--- a/skills/geno-dev-feature-ship/SKILL.md
+++ b/skills/geno-dev-feature-ship/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: geno-dev-feature-ship
+description: >-
+  End-to-end feature shipping — discuss scope, create a GitHub issue, branch,
+  implement, and open a PR. Use when user says /geno-dev-feature-ship.
+argument-hint: "<feature description or issue URL>"
+license: MIT
+metadata:
+  author: 42euge
+  version: "0.1.0"
+---
+
+# Ship Feature
+
+Take a feature idea from discussion through to a pull request: scope the work with the user, create a GitHub issue, branch, implement, and open a PR.
+
+## Input
+
+`$ARGUMENTS` is either a freeform feature description or an existing GitHub issue URL. If empty, ask the user what they want to build.
+
+## Workflow
+
+### 1. Scope the feature
+
+If `$ARGUMENTS` is a GitHub issue URL, fetch it with `gh issue view` and skip to step 2.
+
+Otherwise, start a conversation with the user to understand what they want:
+
+- Ask clarifying questions to nail down the requirements
+- Identify the target repo (use `git remote -v` in the current directory, or ask)
+- Agree on the approach before moving forward
+
+Do not rush past this step. The goal is a shared understanding of what "done" looks like.
+
+### 2. Create a GitHub issue
+
+Draft the issue based on the scoping conversation:
+
+- Title: concise, under 70 characters
+- Body: problem statement, proposed approach, scope (what's in / what's out)
+
+Present the draft to the user with `AskUserQuestion` for approval. Create with `gh issue create`. Record the issue number for the branch name and PR.
+
+Skip this step if `$ARGUMENTS` was already an issue URL.
+
+### 3. Create a branch
+
+Create a feature branch from the current default branch:
+
+```
+git checkout -b <descriptive-branch-name>
+```
+
+Branch name should reflect the feature (e.g., `add-dep-management`, `fix-auth-token`). Push with `-u` to set up tracking.
+
+### 4. Implement
+
+- Explore the codebase to understand the relevant code
+- For non-trivial work, use `EnterPlanMode` to design the approach and get user approval, then `ExitPlanMode` to execute
+- Implement the feature, committing logical units as you go
+- Update documentation (CLAUDE.md, README, etc.) if the feature changes public behavior
+- Run any available tests or linters to verify correctness
+
+### 5. Open a pull request
+
+Create the PR with `gh pr create`:
+
+- Title: short, matches the feature
+- Body: summary bullets, link to the issue (`Closes #N`), test plan
+- Target the default branch
+
+Present the PR URL to the user.
+
+### 6. Wrap up
+
+Summarize what was shipped: the issue, branch, PR, and key implementation decisions. If there are follow-up items (future scope from step 1), mention them so nothing is lost.

--- a/skills/geno-dev/SKILL.md
+++ b/skills/geno-dev/SKILL.md
@@ -3,9 +3,10 @@ name: geno-dev
 description: >-
   Developer and infrastructure utilities — task execution from lab notes,
   git commit history rewriting, worktree management, workspace creation,
-  and session forking.
+  session forking, and end-to-end feature shipping.
   Use when user says /geno-dev-tasks-start, /geno-dev-commits-rewrite,
-  /geno-dev-worktrees-manage, /geno-dev-workspaces-init, or /geno-dev-sessions-fork.
+  /geno-dev-worktrees-manage, /geno-dev-workspaces-init, /geno-dev-sessions-fork,
+  or /geno-dev-feature-ship.
 license: MIT
 metadata:
   author: 42euge
@@ -14,7 +15,7 @@ metadata:
 
 # geno-dev — Developer Utilities
 
-Dev and infrastructure skills for AI coding agents. Task execution, git history rewriting, worktree management, workspace creation, and session forking.
+Dev and infrastructure skills for AI coding agents. Task execution, git history rewriting, worktree management, workspace creation, session forking, and end-to-end feature shipping.
 
 ## Commands
 
@@ -25,6 +26,7 @@ Dev and infrastructure skills for AI coding agents. Task execution, git history 
 | `/geno-dev-worktrees-manage [list\|create\|switch\|prune]` | Manage git worktrees — list, create, switch, and prune |
 | `/geno-dev-workspaces-init [config\|list\|<text>]` | Create development workspaces from issues, tickets, repos, or ideas |
 | `/geno-dev-sessions-fork [session]` | Fork an agent session — extract context to continue in a new session |
+| `/geno-dev-feature-ship [description\|issue URL]` | End-to-end: scope, issue, branch, implement, and PR |
 
 ## Runtime
 


### PR DESCRIPTION
## Summary

- New skill `geno-dev-feature-ship` for end-to-end feature shipping: scope ��� issue → branch → implement → PR
- Accepts a freeform feature description or existing GitHub issue URL
- Guides through scoping discussion, issue drafting, implementation with optional plan mode, and PR creation
- Updated umbrella skill to reference the new command

## Test plan

- [ ] `/geno-dev-feature-ship` with no args prompts for feature description
- [ ] `/geno-dev-feature-ship <description>` starts scoping conversation
- [ ] `/geno-dev-feature-ship <issue-url>` fetches the issue and skips to branching
- [ ] Full workflow produces a valid PR linked to the created issue