### PR TITLE
Add loops sub-skillset: turbocharge and cruise

### DIFF
--- a/.geno-agents
+++ b/.geno-agents
@@ -1,7 +1,8 @@
 role: geno-dev
-description: Developer utilities — task execution, commit rewriting, worktree management, workspace creation
+description: Developer utilities — task execution, commit rewriting, worktree management, workspace creation, agentic loops
 capabilities:
   - dev-tools
   - git-history
   - git-worktrees
   - workspaces
+  - agentic-loops

--- a/GENO.md
+++ b/GENO.md
@@ -1,6 +1,6 @@
 # geno-dev — developer utilities skillset
 
-Developer and infrastructure skills for AI coding agents: task execution from lab notes, git commit history rewriting, worktree management, workspace creation, and session forking.
+Developer and infrastructure skills for AI coding agents: task execution from lab notes, git commit history rewriting, worktree management, workspace creation, session forking, and agentic loops.
 
 ## Skills
 
@@ -12,6 +12,8 @@ Developer and infrastructure skills for AI coding agents: task execution from la
 | geno-dev-worktrees-manage | worktrees | /geno-dev-worktrees-manage |
 | geno-dev-workspaces-init | workspaces | /geno-dev-workspaces-init |
 | geno-dev-sessions-fork | sessions | /geno-dev-sessions-fork |
+| geno-dev-loops-turbocharge | loops | /geno-dev-loops-turbocharge |
+| geno-dev-loops-cruise | loops | /geno-dev-loops-cruise |
 
 ## Repo structure
 
@@ -28,7 +30,9 @@ geno-dev/
 │   ├── geno-dev-sessions-fork/
 │   ├── geno-dev-tasks-start/
 │   ├── geno-dev-workspaces-init/
-│   └── geno-dev-worktrees-manage/
+│   ├── geno-dev-worktrees-manage/
+│   ├── geno-dev-loops-turbocharge/
+│   └── geno-dev-loops-cruise/
 ├── docs/                # MkDocs Material site
 │   ├── index.md
 │   ├── getting-started.md
@@ -49,6 +53,8 @@ Pure markdown skillset — no Python package, no venv, no scripts. Each skill is
 - **worktrees-manage**: Workspace-aware git worktree management with safety protections for Claude Code and geno-tools worktrees.
 - **workspaces-init**: Creates isolated development workspaces from GitHub issues, JIRA tickets, repo names, or feature ideas, with color-coded folder organization.
 - **sessions-fork**: Extracts full session context via geno-mon for continuation in a new session.
+- **loops-turbocharge**: Spec-driven convergence loop — iterates until all acceptance criteria pass.
+- **loops-cruise**: Plan-driven sequential loop — executes a plan one step at a time via agent subagents.
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # geno-dev
 
-Developer and infrastructure skills for AI coding agents. Task execution from lab notes, git commit history rewriting, worktree management, workspace creation, and session forking.
+Developer and infrastructure skills for AI coding agents. Task execution from lab notes, git commit history rewriting, worktree management, workspace creation, session forking, and agentic loops.
 
 ## Install
 
@@ -17,6 +17,8 @@ geno-tools install geno-dev
 | `/geno-dev-worktrees-manage [list\|create\|switch\|prune]` | Manage git worktrees — list, create, switch, and prune |
 | `/geno-dev-workspaces-init [config\|list\|<text>]` | Create development workspaces from issues, tickets, repos, or ideas |
 | `/geno-dev-sessions-fork [session]` | Fork an agent session — extract context to continue in a new session |
+| `/geno-dev-loops-turbocharge [task] [--spec <file>]` | Spec-driven convergence loop — iterate until all acceptance criteria pass |
+| `/geno-dev-loops-cruise [task] [--plan <file>]` | Plan-driven sequential loop — execute a plan one step at a time |
 
 ## Repository structure
 
@@ -38,7 +40,11 @@ geno-dev/
 │   │   └── SKILL.md
 │   ├── geno-dev-workspaces-init/
 │   │   └── SKILL.md
-│   └── geno-dev-worktrees-manage/
+│   ├── geno-dev-worktrees-manage/
+│   │   └── SKILL.md
+│   ├── geno-dev-loops-turbocharge/
+│   │   └── SKILL.md
+│   └── geno-dev-loops-cruise/
 │       └── SKILL.md
 ├── docs/
 │   ├── index.md

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -145,3 +145,67 @@ Workspace settings at `~/.geno/config.yaml` (auto-created on first use):
 
 !!! tip
     Workspaces and worktrees work together: create a workspace with `/geno-dev-workspaces-init`, then use `/geno-dev-worktrees-manage` inside it for branch-level isolation.
+
+---
+
+## Turbocharge Loop
+
+**`/geno-dev-loops-turbocharge [task] [--spec <file>] [--max <n>]`**
+
+Spec-driven convergence loop. Takes a testable specification (test suite, acceptance criteria, type contract) and iterates until every criterion passes.
+
+### Input
+
+- A task pattern to fuzzy-match against geno-notes tasks (optional)
+- `--spec <file>` — path to the spec file (test suite, criteria list, type definitions)
+- `--max <n>` — maximum iterations (default: 8)
+
+If no spec is provided, the skill asks for a test file, acceptance criteria, or API contract.
+
+### Workflow
+
+1. **Load context** — finds geno-notes task, reads spec, creates session directory at `.geno/loops/turbocharge/<timestamp>/`
+2. **Validate spec (baseline)** — runs spec check, records which criteria pass and fail
+3. **Identify gaps** — prioritizes: quick wins, blockers, isolated fixes, then hard items
+4. **Implement fixes** — makes targeted changes for the top gaps. Small and focused per iteration
+5. **Re-validate** — runs spec check again, logs newly-passing criteria as geno-notes milestones
+6. **Loop or complete** — if all pass, done. If not, schedules next iteration (60–120s). Stops at max iterations
+
+### Spec types supported
+
+| Spec type | Validation |
+|---|---|
+| Test file (`.test.*`) | Test runner (`npm test`, `pytest`, etc.) |
+| Type definitions (`.d.ts`, `.pyi`) | Type checker (`tsc`, `mypy`, etc.) |
+| Acceptance criteria (`.md`) | Manual criterion-by-criterion check |
+| API contract (OpenAPI, protobuf) | Contract validation or diff |
+
+!!! tip
+    Best for TDD workflows: write your tests first, then run `/geno-dev-loops-turbocharge --spec tests/my-feature.test.ts` and let it grind until green.
+
+---
+
+## Cruise Loop
+
+**`/geno-dev-loops-cruise [task] [--plan <file>]`**
+
+Plan-driven sequential execution. Takes a plan with numbered steps and executes them one at a time, each in a fresh agent with checkpoint handoff.
+
+### Input
+
+- A task pattern to fuzzy-match against geno-notes tasks (optional)
+- `--plan <file>` — path to a plan file with numbered steps
+
+If no plan is provided, checks `geno-notes plans/` for the task's plan, then asks the user.
+
+### Workflow
+
+1. **Load context** — finds geno-notes task, reads plan, creates session directory at `.geno/loops/cruise/<timestamp>/`
+2. **Parse plan** — extracts numbered steps, creates a checklist, identifies dependencies
+3. **Pick next step** — selects the first uncompleted step, reads previous checkpoint
+4. **Execute step** — spawns an agent with the step description + previous checkpoint. Agent writes result to `checkpoints/step_<n>.md`
+5. **Verify + log** — reads checkpoint, spot-checks changes, logs geno-notes milestone
+6. **Loop or complete** — if more steps, repeat. If all done, write summary. If a step fails twice, stop and ask user
+
+!!! tip
+    Pairs well with plan mode: use `/geno-dev-tasks-start` to plan a complex task, then run `/geno-dev-loops-cruise --plan geno/geno-notes/plans/<task>.md` to execute it.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "geno-dev",
   "version": "0.1.0",
-  "description": "Developer utilities — task execution, commit rewriting, worktree management, workspace creation",
+  "description": "Developer utilities — task execution, commit rewriting, worktree management, workspace creation, agentic loops",
   "skills": {
     "geno-dev": "skills/geno-dev"
   },

--- a/skills/geno-dev-loops-cruise/SKILL.md
+++ b/skills/geno-dev-loops-cruise/SKILL.md
@@ -1,0 +1,192 @@
+---
+name: geno-dev-loops-cruise
+description: >-
+  Plan-driven sequential execution loop — execute a plan one step at a time.
+  Use when user says /geno-dev-loops-cruise.
+argument-hint: "[task] [--plan <file>]"
+license: MIT
+metadata:
+  author: 42euge
+  version: "0.1.0"
+---
+
+# Cruise Loop
+
+Plan-driven sequential execution. Takes a plan (numbered step list) and executes steps one at a time, each in a fresh Agent subagent with checkpoint handoff. Methodical and predictable — no re-planning, no parallelism, just steady forward progress.
+
+## Input
+
+Parse `$ARGUMENTS` for:
+
+- **Task pattern** — fuzzy-matches against geno-notes tasks (optional)
+- **`--plan <file>`** — path to a plan file with numbered steps
+
+Plan discovery order if `--plan` is not provided:
+
+1. Check `geno-notes plans/<task-slug>.md` for the matched task
+2. Check `.geno/loops/cruise/` for a recent session with an unfinished plan
+3. If nothing found, use `AskUserQuestion` to ask the user for one of:
+   - A plan file path
+   - A numbered list of steps (freeform text — write to `.geno/loops/cruise/<session>/plan.md`)
+   - "Create one" — enter `EnterPlanMode`, design a plan, save it, then continue
+
+## When to Use
+
+- You have a **clear, ordered plan** with numbered steps
+- Steps are mostly **sequential** — each builds on the previous
+- Multi-step refactors, migration checklists, documentation across files
+- Following a plan written in a previous planning session
+- Executing a runbook or checklist
+
+Do **not** use when the work needs re-planning as it progresses (use Overdrive), when steps are independent and can run in parallel (use NOS), or when there's no plan yet and the goal is exploratory (use Drift or Boost).
+
+## Workflow
+
+### 1. Load context
+
+- Check for geno-notes project scope: `geno-notes list --project --status active --json`
+- If a task pattern was provided, activate it: `geno-notes start <pattern> --project`
+- Read the plan file
+- Create session directory:
+  ```
+  .geno/loops/cruise/<YYYYMMDD-HHMM>/
+  ├── session.md
+  ├── plan.md          (copy of the plan)
+  └── checkpoints/
+  ```
+- Write `session.md` header:
+  ```markdown
+  # Cruise Session — <YYYY-MM-DD HH:MM>
+  ## Config
+  - Task: <geno-notes task id or "none">
+  - Plan: <plan file path>
+  - Steps: <total count>
+
+  ## Checklist
+  - [ ] Step 1: <description>
+  - [ ] Step 2: <description>
+  ...
+
+  ## Log
+  ```
+
+### 2. Parse plan
+
+Extract the numbered steps from the plan file. For each step, identify:
+
+- **Description** — what to do
+- **Files involved** — which files will be read or modified (if stated)
+- **Dependencies** — whether this step depends on a previous step's output
+- **Verification** — how to confirm the step is done (if stated)
+
+Write the parsed checklist to `session.md`.
+
+### 3. Pick next step
+
+Select the first step in the checklist that is not yet marked `[x]`. Read the checkpoint from the previous step (if any) at `checkpoints/step_<n-1>.md` to understand the current state.
+
+If all steps are done, skip to step 6 (complete).
+
+### 4. Execute step
+
+Spawn an **Agent subagent** with a self-contained prompt including:
+
+- The step description
+- Relevant file paths from the plan
+- The previous step's checkpoint (handoff context)
+- Instructions to write a checkpoint when done
+
+The agent prompt should follow this structure:
+
+```
+You are executing step <n> of a plan for: <task description>
+
+## Previous step
+<checkpoint from step n-1, or "This is the first step">
+
+## Your task
+<step description>
+
+## Files
+<relevant file paths>
+
+## When done
+Write a checkpoint to: <session-dir>/checkpoints/step_<n>.md
+
+Checkpoint format:
+  # Step <n> Checkpoint
+  ## What was done
+  <summary of changes>
+  ## Files modified
+  <list>
+  ## State for next step
+  <anything the next step needs to know>
+  ## Issues encountered
+  <any problems or deviations from plan>
+```
+
+Wait for the agent to complete and read its checkpoint.
+
+### 5. Verify + log
+
+Read the agent's checkpoint at `checkpoints/step_<n>.md`:
+
+- Verify the step's claimed changes actually exist (spot-check modified files)
+- If verification is defined in the plan, run it (test command, type check, etc.)
+- Update `session.md`: mark the step `[x]` in the checklist, append a log entry:
+  ```markdown
+  ### Step <n> — <timestamp>
+  <summary from checkpoint>
+  ```
+- Log to geno-notes:
+  ```bash
+  geno-notes note "Cruise step <n>/<total>: <summary>" --task <id> --kind milestone --project
+  ```
+
+If verification fails:
+- If this is the first failure for this step, retry (go back to step 4)
+- If this is the second failure, stop and ask the user for guidance via `AskUserQuestion`
+
+### 6. Loop or complete
+
+**If more steps remain:**
+- Go back to step 3 (pick next step)
+- No delay needed between steps — Agent subagents already provide fresh context
+
+**If all steps are done:**
+1. Write final summary to `session.md`:
+   ```markdown
+   ## Summary
+   - Steps completed: <n>/<total>
+   - Duration: <start to end>
+   - Key changes: <list>
+   ```
+2. Log completion: `geno-notes note "Cruise complete: <n> steps executed" --task <id> --kind milestone --project`
+3. If the task is fully done: `geno-notes done <id> --project`
+4. Report to the user what was accomplished
+
+**If a step failed twice and user guidance is needed:**
+1. Write partial summary to `session.md`
+2. Log: `geno-notes note "Cruise paused at step <n>: <error>" --task <id> --kind bug --project`
+3. Present the issue to the user and wait for direction
+
+## Error Recovery
+
+- If an Agent subagent fails to write a checkpoint, read the agent's output directly and construct the checkpoint manually.
+- If a step makes changes that break a previous step's work, revert the step's changes and flag the conflict. Do not attempt to fix inter-step conflicts automatically — ask the user.
+- If the plan file references files that don't exist, skip to the next step and log the missing file. The plan may be outdated.
+- If `geno-notes` CLI fails, continue executing steps — don't let journal failures block plan execution. Log the error to `session.md`.
+- Never do destructive git operations (force push, hard reset, branch delete) inside the loop.
+- If context grows too large (agent subagents help prevent this), write a comprehensive checkpoint and continue with fresh agents.
+
+## What NOT to Do
+
+- **Don't re-plan mid-execution.** If the plan needs changing, stop and tell the user. Re-planning is Overdrive's job.
+- **Don't skip steps without user approval.** Even if a step seems unnecessary, execute it or ask first.
+- **Don't parallelize steps.** Steps are sequential by design. If you notice independent steps, suggest NOS for next time.
+- **Don't modify the plan file.** The plan is the contract. Deviations go in `session.md` and geno-notes, not the plan itself.
+- **Don't continue after two failures on the same step.** Escalate to the user.
+
+## Runtime
+
+No venv or scripts — pure markdown workflow. Uses Agent subagents for step execution with checkpoint-based handoff.

--- a/skills/geno-dev-loops-turbocharge/SKILL.md
+++ b/skills/geno-dev-loops-turbocharge/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: geno-dev-loops-turbocharge
+description: >-
+  Spec-driven convergence loop — iterate until all acceptance criteria pass.
+  Use when user says /geno-dev-loops-turbocharge.
+argument-hint: "[task] [--spec <file>] [--max <n>]"
+license: MIT
+metadata:
+  author: 42euge
+  version: "0.1.0"
+---
+
+# Turbocharge Loop
+
+Spec-driven convergence loop. Takes a testable specification (test file, acceptance criteria, type contract) and iterates until every criterion passes. Each iteration validates, identifies gaps, implements fixes, and re-validates. The loop converges toward zero failures.
+
+## Input
+
+Parse `$ARGUMENTS` for:
+
+- **Task pattern** — fuzzy-matches against geno-notes tasks (optional)
+- **`--spec <file>`** — path to the spec file (test suite, criteria list, type definitions)
+- **`--max <n>`** — maximum iterations (default: 8)
+
+If no spec is provided, use `AskUserQuestion` to ask the user for one of:
+1. A test file to run
+2. A list of acceptance criteria (freeform text — write them to `.geno/loops/turbocharge/<session>/spec.md`)
+3. A type contract or API spec file
+
+## When to Use
+
+- You have a **testable target**: test suite, type definitions, acceptance criteria, API contract
+- The work is **convergence-oriented** — each iteration should get closer to passing
+- TDD: write tests first, then loop until green
+- Contract-first development: implement until the interface is satisfied
+- Migrations with known targets: old behavior must be preserved in new code
+
+Do **not** use when the goal is exploratory (use Drift), when there's no spec to validate against (use Boost), or when the work has many independent items (use NOS).
+
+## Workflow
+
+### 1. Load context
+
+- Check for geno-notes project scope: `geno-notes list --project --status active --json`
+- If a task pattern was provided, activate it: `geno-notes start <pattern> --project`
+- Read the spec file (or the criteria written during Input)
+- Create session directory:
+  ```
+  .geno/loops/turbocharge/<YYYYMMDD-HHMM>/
+  ├── session.md
+  ├── spec.md          (copy of spec or user-provided criteria)
+  └── checkpoints/
+  ```
+- Write `session.md` header:
+  ```markdown
+  # Turbocharge Session — <YYYY-MM-DD HH:MM>
+  ## Config
+  - Task: <geno-notes task id or "none">
+  - Spec: <spec file path>
+  - Max iterations: <n>
+
+  ## Log
+  ```
+
+### 2. Validate spec (baseline)
+
+Run the spec check. The validation method depends on the spec type:
+
+| Spec type | Validation command |
+|---|---|
+| Test file (`.test.*`, `*_test.*`) | Run the test runner (`npm test`, `pytest`, `go test`, etc.) |
+| Type definitions (`.d.ts`, `.pyi`) | Run the type checker (`tsc --noEmit`, `mypy`, etc.) |
+| Acceptance criteria (`.md` list) | Grep/check each criterion manually against the codebase |
+| API contract (OpenAPI, protobuf) | Run contract validation tool or diff against implementation |
+
+Record baseline results in `session.md`:
+```markdown
+### Iteration 0 (baseline) — <timestamp>
+- Passing: 3/10
+- Failing: 7/10
+- Failures: <list each failing criterion>
+```
+
+If everything already passes, write a note and stop — no work needed.
+
+### 3. Identify gaps
+
+Compare passing vs. failing criteria. Prioritize:
+
+1. **Quick wins** — criteria that are close to passing (small changes needed)
+2. **Blockers** — criteria that other failing criteria depend on
+3. **Isolated** — criteria that can be fixed without touching shared code
+4. **Hard** — criteria requiring significant design or multi-file changes
+
+Pick the top 1–3 gaps to address this iteration. Write the plan to `session.md`.
+
+### 4. Implement fixes
+
+Make targeted changes to close the selected gaps:
+
+- Keep changes **small and focused** — one logical change per iteration
+- Do not touch code unrelated to the failing criteria
+- Do not modify the spec itself
+- If a fix requires a design decision, log it: `geno-notes note "<decision>" --task <id> --kind decision --project`
+
+### 5. Re-validate
+
+Run the spec check again (same method as step 2). Log results to `session.md`:
+
+```markdown
+### Iteration <n> — <timestamp>
+- Passing: 7/10 (+4)
+- Failing: 3/10 (-4)
+- Fixed this iteration: <list>
+- Still failing: <list>
+```
+
+For each newly-passing criterion, log a milestone:
+```bash
+geno-notes note "Turbocharge: <criterion> now passing" --task <id> --kind milestone --project
+```
+
+### 6. Loop or complete
+
+**If all criteria pass:**
+1. Write final summary to `session.md`
+2. Log completion: `geno-notes note "Turbocharge complete: all <n> criteria passing after <iterations> iterations" --task <id> --kind milestone --project`
+3. If the task is fully done: `geno-notes done <id> --project`
+4. Stop the loop
+
+**If criteria remain and iterations < max:**
+1. Call `ScheduleWakeup` with delay 60–120 seconds (stay in prompt cache)
+2. On wake, repeat from step 3
+
+**If max iterations reached:**
+1. Write summary to `session.md` with remaining failures
+2. Log: `geno-notes note "Turbocharge stopped at max iterations: <passing>/<total> passing" --task <id> --kind note --project`
+3. Report remaining gaps to the user
+4. Stop the loop
+
+## Error Recovery
+
+- If a spec check command fails (not "tests failed" but "command crashed"), retry once. If it fails again, log the error to `session.md` and stop — the spec runner itself is broken.
+- If an iteration makes things worse (more failures than before), revert the changes (`git checkout -- .`) and try a different approach. Log the revert.
+- If the same criterion fails 3 iterations in a row with the same error, flag it as stuck and skip to other criteria.
+- If `geno-notes` CLI fails, continue the loop — don't let journal failures block convergence work. Log the geno-notes error to `session.md` instead.
+- Never do destructive git operations (force push, hard reset, branch delete) inside the loop.
+
+## What NOT to Do
+
+- **Don't modify the spec.** The spec is the target, not the implementation. If the spec is wrong, stop and tell the user.
+- **Don't skip failing criteria.** Every criterion must either pass or be explicitly flagged as stuck.
+- **Don't make unrelated changes.** If you notice other issues, log them as `geno-notes note --kind bug` but don't fix them in this loop.
+- **Don't continue past max iterations.** Respect the limit — infinite loops waste resources.
+- **Don't run without a spec.** If there's nothing to validate against, suggest Boost or Drift instead.
+
+## Runtime
+
+No venv or scripts — pure markdown workflow. Uses `ScheduleWakeup` for self-pacing within `/loop`.

--- a/skills/geno-dev/SKILL.md
+++ b/skills/geno-dev/SKILL.md
@@ -3,10 +3,11 @@ name: geno-dev
 description: >-
   Developer and infrastructure utilities — task execution from lab notes,
   git commit history rewriting, worktree management, workspace creation,
-  session forking, end-to-end feature shipping, and issue-driven development.
+  session forking, end-to-end feature shipping, issue-driven development, and agentic loops.
   Use when user says /geno-dev-tasks-start, /geno-dev-commits-rewrite,
   /geno-dev-worktrees-manage, /geno-dev-workspaces-init, /geno-dev-sessions-fork,
-  /geno-dev-feature-ship, or /geno-dev-issue-work.
+  /geno-dev-feature-ship, /geno-dev-issue-work, /geno-dev-loops-turbocharge,
+  or /geno-dev-loops-cruise.
 license: MIT
 metadata:
   author: 42euge
@@ -15,7 +16,7 @@ metadata:
 
 # geno-dev — Developer Utilities
 
-Dev and infrastructure skills for AI coding agents. Task execution, git history rewriting, worktree management, workspace creation, session forking, end-to-end feature shipping, and issue-driven development.
+Dev and infrastructure skills for AI coding agents. Task execution, git history rewriting, worktree management, workspace creation, session forking, end-to-end feature shipping, issue-driven development, and agentic loops.
 
 ## Commands
 
@@ -28,6 +29,8 @@ Dev and infrastructure skills for AI coding agents. Task execution, git history 
 | `/geno-dev-sessions-fork [session]` | Fork an agent session — extract context to continue in a new session |
 | `/geno-dev-feature-ship [description\|issue URL]` | End-to-end: scope, issue, branch, implement, and PR |
 | `/geno-dev-issue-work [number\|query\|URL]` | Pick a GitHub issue or JIRA ticket and work on it (normal or loop mode) |
+| `/geno-dev-loops-turbocharge [task] [--spec <file>]` | Spec-driven convergence loop — iterate until all acceptance criteria pass |
+| `/geno-dev-loops-cruise [task] [--plan <file>]` | Plan-driven sequential loop — execute a plan one step at a time |
 
 ## Runtime
 


### PR DESCRIPTION
## Summary

- Introduces the `loops` sub-skillset with two agentic loop strategies, both integrated with geno-notes for task/journal tracking
- **Turbocharge** (`/geno-dev-loops-turbocharge`) — spec-driven convergence loop that iterates until all acceptance criteria pass (tests, types, contracts). Uses ScheduleWakeup for self-pacing
- **Cruise** (`/geno-dev-loops-cruise`) — plan-driven sequential executor that takes a numbered plan and executes steps one at a time via Agent subagents with checkpoint handoff

Phase 1 of 3 — six more variants planned for future branches: overdrive, nos, boost, drift, ignition, autopilot.

Also includes nomenclature standardization from the parent branch (pluralized sub-skillsets, canonical naming).

## Test plan

- [ ] Verify both SKILL.md files load correctly as skills (`npx skills add 42euge/geno-dev`)
- [ ] Run `/geno-dev-loops-turbocharge --spec <test-file>` against a failing test suite and confirm convergence loop behavior
- [ ] Run `/geno-dev-loops-cruise --plan <plan-file>` with a multi-step plan and confirm sequential checkpoint execution
- [ ] Confirm geno-notes integration: task activation, milestone logging, completion marking
- [ ] Verify all manifests are consistent (CLAUDE.md, umbrella SKILL.md, README.md, docs/commands.md, .geno-agents, package.json)