### PR TITLE
Add scheduling-snooze skill

### DIFF
--- a/.geno-agents
+++ b/.geno-agents
@@ -1,8 +1,9 @@
 role: geno-dev
-description: Developer utilities — task execution, commit rewriting, worktree management, workspace creation, agentic loops
+description: Developer utilities — task execution, commit rewriting, worktree management, workspace creation, agentic loops, scheduling
 capabilities:
   - dev-tools
   - git-history
   - git-worktrees
   - workspaces
   - agentic-loops
+  - scheduling

--- a/GENO.md
+++ b/GENO.md
@@ -1,6 +1,6 @@
 # geno-dev — developer utilities skillset
 
-Developer and infrastructure skills for AI coding agents: task execution from lab notes, git commit history rewriting, worktree management, workspace creation, session forking, and agentic loops.
+Developer and infrastructure skills for AI coding agents: task execution from lab notes, git commit history rewriting, worktree management, workspace creation, session forking, agentic loops, and scheduled snoozing.
 
 ## Skills
 
@@ -15,6 +15,7 @@ Developer and infrastructure skills for AI coding agents: task execution from la
 | geno-dev-loops-turbocharge | loops | /geno-dev-loops-turbocharge |
 | geno-dev-loops-cruise | loops | /geno-dev-loops-cruise |
 | geno-dev-prs-check | prs | /geno-dev-prs-check |
+| geno-dev-scheduling-snooze | scheduling | /geno-dev-scheduling-snooze |
 
 ## Repo structure
 
@@ -34,7 +35,8 @@ geno-dev/
 │   ├── geno-dev-worktrees-manage/
 │   ├── geno-dev-loops-turbocharge/
 │   ├── geno-dev-loops-cruise/
-│   └── geno-dev-prs-check/
+│   ├── geno-dev-prs-check/
+│   └── geno-dev-scheduling-snooze/
 ├── docs/                # MkDocs Material site
 │   ├── index.md
 │   ├── getting-started.md
@@ -60,6 +62,7 @@ Pure markdown skillset — no Python package, no venv, no scripts. Each skill is
 - **loops-turbocharge**: Spec-driven convergence loop — iterates until all acceptance criteria pass.
 - **loops-cruise**: Plan-driven sequential loop — executes a plan one step at a time via agent subagents.
 - **prs-check**: Checks open PRs, classifies by status (closeable/stale/blocked/draft/approved), renders a table with links.
+- **scheduling-snooze**: Delays session work until a specified time using natural language, with chained wakeups for long delays.
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # geno-dev
 
-Developer and infrastructure skills for AI coding agents. Task execution from lab notes, git commit history rewriting, worktree management, workspace creation, session forking, and agentic loops.
+Developer and infrastructure skills for AI coding agents. Task execution from lab notes, git commit history rewriting, worktree management, workspace creation, session forking, agentic loops, and scheduled snoozing.
 
 ## Install
 
@@ -20,6 +20,7 @@ geno-tools install geno-dev
 | `/geno-dev-loops-turbocharge [task] [--spec <file>]` | Spec-driven convergence loop — iterate until all acceptance criteria pass |
 | `/geno-dev-loops-cruise [task] [--plan <file>]` | Plan-driven sequential loop — execute a plan one step at a time |
 | `/geno-dev-prs-check [repo\|--all]` | Check open PRs and flag ones that may need closing |
+| `/geno-dev-scheduling-snooze <time> [prompt]` | Snooze session until a specified time, then execute a prompt |
 
 ## Repository structure
 
@@ -47,7 +48,9 @@ geno-dev/
 │   │   └── SKILL.md
 │   ├── geno-dev-loops-cruise/
 │   │   └── SKILL.md
-│   └── geno-dev-prs-check/
+│   ├── geno-dev-prs-check/
+│   │   └── SKILL.md
+│   └── geno-dev-scheduling-snooze/
 │       └── SKILL.md
 ├── docs/
 │   ├── index.md

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -261,3 +261,45 @@ A markdown table sorted by priority (closeable first), always including a link:
 ```
 
 Followed by a summary line with counts per status and a hint for closing stale PRs.
+
+---
+
+## Snooze
+
+**`/geno-dev-scheduling-snooze <time> [prompt]`**
+
+Delay the current session's work until a specified time. Parses natural language time expressions and schedules a wakeup via `ScheduleWakeup`.
+
+### Input
+
+A time expression followed by an optional prompt describing what to do on wakeup.
+
+| Format | Examples |
+|---|---|
+| Absolute clock time | `3:30 AM`, `15:30`, `3:30am` |
+| Relative duration | `in 2 hours`, `45m`, `2h` |
+| Named time | `tomorrow at 9am`, `tonight at midnight` |
+
+### Workflow
+
+1. **Parse time** — extracts time expression, resolves to seconds from now
+2. **Resolve prompt** — uses provided prompt or asks the user
+3. **Chain if needed** — if delay exceeds 3600s (ScheduleWakeup max), chains hourly wakeups that re-snooze until the target
+4. **Schedule** — calls ScheduleWakeup with computed delay and prompt
+5. **Confirm** — reports target time, delay, chain count, and wakeup action
+
+### Examples
+
+```
+/geno-dev-scheduling-snooze 3:30 AM start working on the auth refactor
+→ Snoozing until 3:30 AM PDT (in 3h 19m). On wake: "start working on the auth refactor"
+
+/geno-dev-scheduling-snooze 45m run the benchmark suite
+→ Snoozing for 45 minutes. On wake: "run the benchmark suite"
+
+/geno-dev-scheduling-snooze in 10 minutes
+→ (asks what to do on wakeup, then schedules)
+```
+
+!!! tip
+    For delays longer than 1 hour, the skill automatically chains hourly wakeups. Each hop re-checks the clock and re-snoozes until the target time is reached.

--- a/skills/geno-dev-scheduling-snooze/SKILL.md
+++ b/skills/geno-dev-scheduling-snooze/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: geno-dev-scheduling-snooze
+description: >-
+  Snooze the current session — delay work until a specified time using natural
+  language ("3:30 AM", "in 2 hours", "tomorrow at 9am"). Wraps ScheduleWakeup
+  with smart time parsing.
+  Use when user says /geno-dev-scheduling-snooze.
+argument-hint: "<time expression> [prompt]"
+license: MIT
+metadata:
+  author: 42euge
+  version: "0.1.0"
+---
+
+# Snooze
+
+Delay the current session's work until a specified time. Parses natural language time expressions and schedules a wakeup via the `ScheduleWakeup` tool.
+
+## Usage
+
+```
+/geno-dev-scheduling-snooze <time> [prompt to execute on wake]
+```
+
+## Input
+
+`<args>` contains a time expression and optionally a prompt describing what to do when the snooze ends.
+
+**Time expression** — the first part of the argument, parsed as one of:
+
+| Format | Examples | Resolution |
+|---|---|---|
+| Absolute clock time | `3:30 AM`, `15:30`, `3:30am` | Next occurrence of that time today, or tomorrow if already past |
+| Relative duration | `in 2 hours`, `in 30 minutes`, `45m`, `2h` | From now |
+| Named time | `tomorrow at 9am`, `tonight at midnight` | Resolved to absolute then to seconds |
+
+**Prompt** — everything after the time expression. If provided, this is passed to `ScheduleWakeup` as the prompt to fire on wakeup. If omitted, the skill asks the user what they'd like to do when the snooze ends.
+
+## Workflow
+
+### 1. Get current time
+
+Run `date "+%Y-%m-%d %H:%M:%S %Z"` to get the current local time and timezone.
+
+### 2. Parse the time expression
+
+Extract the time expression from the arguments. Parse it into an absolute target time.
+
+**Rules:**
+- If the target time is in the past (e.g., user says "3:30 AM" but it's already 4 AM), assume **tomorrow**.
+- Clamp the computed delay to the ScheduleWakeup range: minimum 60 seconds, maximum 3600 seconds.
+- If the target is more than 3600 seconds away, use **chained snoozes**: schedule a wakeup at the maximum delay (3600s) with a re-snooze prompt that will repeat until the target time is reached. The re-snooze prompt must include the original target time and the original wakeup prompt so context is preserved across hops.
+
+### 3. Determine the wakeup prompt
+
+- If the user provided a prompt after the time expression, use it verbatim.
+- If no prompt was provided, ask the user: "What should I work on when the snooze ends?"
+- For chained snoozes (target > 3600s away), the wakeup prompt is a `/loop`-compatible re-snooze instruction that re-checks the time and either re-snoozes or fires the original prompt.
+
+### 4. Handle chained snoozes
+
+When the delay exceeds 3600 seconds, build a chained wakeup:
+
+1. Compute `remaining = target_time - now` in seconds.
+2. If `remaining > 3600`, schedule a 3600s wakeup with a prompt that:
+   - States the original target time (absolute, with timezone)
+   - Includes the original wakeup prompt
+   - Instructs the agent to re-invoke the snooze skill with the remaining time
+3. If `remaining <= 3600`, schedule the final wakeup with the original prompt.
+
+The chained prompt format:
+
+```
+Snooze chain — target: <YYYY-MM-DD HH:MM:SS TZ>. Check the current time.
+If the target has not been reached, re-snooze for the remaining duration.
+When the target is reached, execute: <original prompt>
+```
+
+### 5. Schedule the wakeup
+
+Call `ScheduleWakeup` with:
+- `delaySeconds`: the computed delay (clamped to [60, 3600])
+- `reason`: a short human-readable description, e.g., "snoozing until 3:30 AM PST"
+- `prompt`: the wakeup prompt (direct or chained)
+
+### 6. Confirm to the user
+
+Report:
+- The target wakeup time (absolute, in local timezone)
+- The delay in human-friendly format ("in 3 hours and 19 minutes")
+- Whether chaining is needed ("will re-snooze every hour until then")
+- What will happen on wakeup (the prompt, summarized)
+
+## Examples
+
+```
+/geno-dev-scheduling-snooze 3:30 AM start working on the auth refactor
+→ Snoozing until 3:30 AM PDT (in 3h 19m, 3 chained wakeups). On wake: "start working on the auth refactor"
+
+/geno-dev-scheduling-snooze in 10 minutes
+→ What should I work on when the snooze ends?
+→ (user responds)
+→ Snoozing for 10 minutes. On wake: "<user's response>"
+
+/geno-dev-scheduling-snooze 45m run the benchmark suite
+→ Snoozing for 45 minutes. On wake: "run the benchmark suite"
+```
+
+## Edge cases
+
+- **Under 60 seconds**: ScheduleWakeup clamps to 60s minimum. Tell the user: "Minimum snooze is 60 seconds."
+- **Ambiguous time**: If the time expression is ambiguous (e.g., "3:30" without AM/PM), infer based on context — if it's currently 2 AM, "3:30" likely means 3:30 AM. If it's 2 PM, "3:30" likely means 3:30 PM. When uncertain, ask.
+- **No arguments**: Ask the user for a time expression.

--- a/skills/geno-dev/SKILL.md
+++ b/skills/geno-dev/SKILL.md
@@ -3,11 +3,12 @@ name: geno-dev
 description: >-
   Developer and infrastructure utilities — task execution from lab notes,
   git commit history rewriting, worktree management, workspace creation,
-  session forking, end-to-end feature shipping, issue-driven development, and agentic loops.
+  session forking, end-to-end feature shipping, issue-driven development,
+  agentic loops, and scheduled snoozing.
   Use when user says /geno-dev-tasks-start, /geno-dev-commits-rewrite,
   /geno-dev-worktrees-manage, /geno-dev-workspaces-init, /geno-dev-sessions-fork,
   /geno-dev-feature-ship, /geno-dev-issue-work, /geno-dev-loops-turbocharge,
-  /geno-dev-loops-cruise, or /geno-dev-prs-check.
+  /geno-dev-loops-cruise, /geno-dev-prs-check, or /geno-dev-scheduling-snooze.
 license: MIT
 metadata:
   author: 42euge
@@ -16,7 +17,7 @@ metadata:
 
 # geno-dev — Developer Utilities
 
-Dev and infrastructure skills for AI coding agents. Task execution, git history rewriting, worktree management, workspace creation, session forking, end-to-end feature shipping, issue-driven development, agentic loops, and PR checking.
+Dev and infrastructure skills for AI coding agents. Task execution, git history rewriting, worktree management, workspace creation, session forking, end-to-end feature shipping, issue-driven development, agentic loops, PR checking, and scheduled snoozing.
 
 ## Commands
 
@@ -32,6 +33,7 @@ Dev and infrastructure skills for AI coding agents. Task execution, git history 
 | `/geno-dev-loops-turbocharge [task] [--spec <file>]` | Spec-driven convergence loop — iterate until all acceptance criteria pass |
 | `/geno-dev-loops-cruise [task] [--plan <file>]` | Plan-driven sequential loop — execute a plan one step at a time |
 | `/geno-dev-prs-check [repo\|--all]` | Check open PRs and flag ones that may need closing |
+| `/geno-dev-scheduling-snooze <time> [prompt]` | Snooze session until a specified time, then execute a prompt |
 
 ## Runtime
 


### PR DESCRIPTION
## Summary

- **New skill**: `geno-dev-scheduling-snooze` — delay session work until a specified time using natural language time expressions (`3:30 AM`, `in 2 hours`, `45m`, `tomorrow at 9am`)
- Wraps `ScheduleWakeup` with smart time parsing and automatic chained wakeups for delays exceeding the 3600s maximum
- Updates umbrella skill, GENO.md, README, docs, and .geno-agents

## Test plan

- [ ] Invoke `/geno-dev-scheduling-snooze 2m test` — verify wakeup fires after ~2 minutes
- [ ] Invoke `/geno-dev-scheduling-snooze 3:30 AM do something` — verify chained snooze logic for long delays
- [ ] Invoke `/geno-dev-scheduling-snooze` with no args — verify it asks for time expression
- [ ] Verify skill appears in available skills list after install