### PR TITLE
Add branches-audit skill

### DIFF
--- a/GENO.md
+++ b/GENO.md
@@ -15,6 +15,7 @@ Developer and infrastructure skills for AI coding agents: task execution from la
 | geno-dev-loops-turbocharge | loops | /geno-dev-loops-turbocharge |
 | geno-dev-loops-cruise | loops | /geno-dev-loops-cruise |
 | geno-dev-prs-check | prs | /geno-dev-prs-check |
+| geno-dev-branches-audit | branches | /geno-dev-branches-audit |
 | geno-dev-scheduling-snooze | scheduling | /geno-dev-scheduling-snooze |
 | geno-dev-feature-ship | feature-ship | /geno-dev-feature-ship |
 | geno-dev-issue-work | issue-work | /geno-dev-issue-work |
@@ -38,6 +39,7 @@ geno-dev/
 │   ├── geno-dev-loops-turbocharge/
 │   ├── geno-dev-loops-cruise/
 │   ├── geno-dev-prs-check/
+│   ├── geno-dev-branches-audit/
 │   ├── geno-dev-scheduling-snooze/
 │   ├── geno-dev-feature-ship/
 │   └── geno-dev-issue-work/
@@ -66,6 +68,7 @@ Pure markdown skillset — no Python package, no venv, no scripts. Each skill is
 - **loops-turbocharge**: Spec-driven convergence loop — iterates until all acceptance criteria pass.
 - **loops-cruise**: Plan-driven sequential loop — executes a plan one step at a time via agent subagents.
 - **prs-check**: Checks open PRs, classifies by status (closeable/stale/blocked/draft/approved), renders a table with links.
+- **branches-audit**: Audits all branches across a workspace or repo, classifying by PR status and suggesting next actions.
 - **scheduling-snooze**: Delays session work until a specified time using natural language, with chained wakeups for long delays.
 
 ## Conventions

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -264,6 +264,41 @@ Followed by a summary line with counts per status and a hint for closing stale P
 
 ---
 
+## Audit Branches
+
+**`/geno-dev-branches-audit [repo|--all]`**
+
+Audit all branches across a workspace or repo. For each branch, determines whether a PR exists, what state it's in, and what action is needed.
+
+### Input
+
+- Empty — audits the current repo
+- A repo name or `owner/repo` — audits that specific repo
+- `--all` — if inside a workspace, audits all repos in `.geno/workspace.yaml`
+
+### Status Tags
+
+| Tag | Meaning |
+|-----|---------|
+| `PR MERGED` | PR was merged but branch still exists (cleanup candidate) |
+| `PR CLOSED` | PR was closed without merge, branch still exists |
+| `PR APPROVED` | PR approved, ready to merge |
+| `PR BLOCKED` | Changes requested or merge conflicts |
+| `PR DRAFT` | PR is a draft |
+| `PR OPEN` | Normal open PR |
+| `NEEDS PR` | Has commits ahead of default, no PR exists |
+| `STALE` | No PR, no updates in 30+ days |
+| `NO CHANGES` | Branch has zero commits ahead of default (delete candidate) |
+
+### Output
+
+A table per repo showing branch name, commits ahead, age, worktree path, PR link, and status tag. Followed by grouped suggested actions with copy-pasteable commands.
+
+!!! tip
+    Complements `/geno-dev-prs-check` which only looks at open PRs. This skill finds branches that *don't* have PRs yet, and branches whose PRs have already been merged or closed.
+
+---
+
 ## Snooze
 
 **`/geno-dev-scheduling-snooze <time> [prompt]`**

--- a/skills/geno-dev-branches-audit/SKILL.md
+++ b/skills/geno-dev-branches-audit/SKILL.md
@@ -1,0 +1,220 @@
+---
+name: geno-dev-branches-audit
+description: >-
+  Audit all branches across a workspace or repo — find branches needing PRs,
+  PRs ready to merge, and stale branches to clean up.
+  Use when user says /geno-dev-branches-audit.
+argument-hint: "[repo|--all]"
+license: MIT
+metadata:
+  author: 42euge
+  version: "0.1.0"
+---
+
+# Audit Branches
+
+Audit all branches across a workspace or repo to answer: "What's the status of everything?" For each branch, determines whether a PR exists, what state it's in, and what action is needed — surfacing branches that need PRs, PRs ready to merge, and stale branches to clean up.
+
+## Input
+
+`$ARGUMENTS` can be:
+
+- Empty — audits the current repo (from `git remote -v`)
+- A repo name or `owner/repo` — audits that specific repo
+- `--all` — if inside a workspace, audits all repos listed in `.geno/workspace.yaml`
+
+## Workflow
+
+### 1. Resolve repos
+
+- If `--all` and inside a workspace: read `.geno/workspace.yaml` and collect all repo entries (url + path).
+- If a repo argument is given: use it (expand bare names to `42euge/<name>`).
+- Otherwise: read `git remote -v` from cwd to get the current repo's `owner/repo` and local path.
+
+If no repo can be resolved, tell the user and stop.
+
+For each repo, determine the local clone path:
+- In workspace mode: `<workspace>/<repo.path>/`
+- Otherwise: the current working directory
+
+### 2. Discover branches
+
+For each repo, collect all non-default branches from three sources:
+
+**a. Local branches:**
+
+```bash
+git -C <repo-path> branch --format='%(refname:short) %(upstream:short) %(committerdate:iso8601)'
+```
+
+**b. Worktree branches:**
+
+```bash
+git -C <repo-path> worktree list --porcelain
+```
+
+Parse the output to extract branches checked out in worktrees. Record each worktree path.
+
+**c. Remote-only branches (no local tracking branch):**
+
+```bash
+git -C <repo-path> branch -r --format='%(refname:short)' | grep -v HEAD
+```
+
+Include remote branches that have no corresponding local branch (strip the `origin/` prefix and check). These represent branches pushed by other agents or sessions.
+
+**Determine the default branch:**
+
+```bash
+git -C <repo-path> symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||'
+```
+
+If that fails, fall back to checking for `main` then `master`. Exclude the default branch from the audit list.
+
+Also exclude `gh-pages` — it is a deployment branch, not a feature branch.
+
+Deduplicate: if a branch appears in both local and worktree lists, merge the entries (keep the worktree path info).
+
+Filter out any branches checked out in paths containing `/.claude/worktrees/` — these are managed by Claude Code's isolation system and are not part of the user's branch workflow.
+
+### 3. Analyze each branch
+
+For each branch, gather:
+
+**a. Commits ahead of default branch:**
+
+```bash
+git -C <repo-path> rev-list --count origin/<default>..<branch>
+```
+
+If the branch only exists on the remote (no local), use:
+
+```bash
+git -C <repo-path> rev-list --count origin/<default>..origin/<branch>
+```
+
+**b. Last commit date:**
+
+```bash
+git -C <repo-path> log -1 --format='%ci' <branch>
+```
+
+**c. PR status on GitHub:**
+
+```bash
+gh pr list --repo <owner/repo> --head <branch> --state all --json number,title,state,isDraft,reviewDecision,url,mergedAt,mergeable --limit 1
+```
+
+Using `--state all` captures open, merged, and closed PRs. If multiple PRs exist for the same branch, use the most recent one.
+
+**d. Worktree association:**
+
+Check if this branch has an active worktree (from step 2b). Record the worktree path if so.
+
+### 4. Classify each branch
+
+Assign exactly one status tag. Evaluate in this order (first match wins):
+
+| Tag | Condition |
+|-----|-----------|
+| `PR MERGED` | PR exists with `state: MERGED` and branch still exists locally or on remote |
+| `PR CLOSED` | PR exists with `state: CLOSED` (not merged) and branch still exists |
+| `PR APPROVED` | PR is open and `reviewDecision: APPROVED` |
+| `PR BLOCKED` | PR is open and (`reviewDecision: CHANGES_REQUESTED` or `mergeable: CONFLICTING`) |
+| `PR DRAFT` | PR is open and `isDraft: true` |
+| `PR OPEN` | PR is open (none of the above conditions) |
+| `STALE` | No PR exists, has commits ahead, and last commit is 30+ days old |
+| `NEEDS PR` | No PR exists and branch has 1+ commits ahead of default |
+| `NO CHANGES` | Branch exists but has 0 commits ahead of default |
+
+### 5. Render the table
+
+For each repo, output an H2 header and a markdown table sorted by status tag priority (PR MERGED first as cleanup candidates, then actionable items, then informational):
+
+Columns:
+
+| Column | Source |
+|--------|--------|
+| Branch | Branch name |
+| Commits | Number of commits ahead of default |
+| Age | Days since last commit |
+| Worktree | Worktree path (shortened with `~`) or `—` |
+| PR | PR number with link (e.g., `[#42](url)`) or `—` |
+| Status | The tag from step 4 |
+
+Example output:
+
+```
+## geno-dev (42euge/geno-dev)
+
+| Branch | Commits | Age | Worktree | PR | Status |
+|--------|---------|-----|----------|----|--------|
+| feat/old-feature | 3 | 45d | — | [#47](url) | PR MERGED |
+| chore/cleanup | 1 | 60d | — | — | STALE |
+| feat/new-auth | 5 | 2d | ~/.geno/worktrees/geno-dev/feat/new-auth | — | NEEDS PR |
+| docs/improve-site | 8 | 1d | — | [#52](url) | PR OPEN |
+| feat/gt-snooze | 12 | 3d | ~/.geno/worktrees/geno-dev/feat/gt-snooze | [#55](url) | PR DRAFT |
+| stale-experiment | 0 | 90d | — | — | NO CHANGES |
+```
+
+### 6. Suggested actions
+
+After the table, group branches by action type and print specific, copy-pasteable commands:
+
+**Cleanup (merged/closed PRs, no-change branches):**
+
+```
+Delete merged branch feat/old-feature:
+  git -C <repo-path> branch -d feat/old-feature && git push origin --delete feat/old-feature
+
+Delete no-change branch stale-experiment:
+  git -C <repo-path> branch -d stale-experiment
+```
+
+**Ready to merge:**
+
+```
+Merge PR #52 (docs/improve-site, approved):
+  gh pr merge 52 --repo 42euge/geno-dev
+```
+
+**Branches needing PRs:**
+
+```
+Open PR for feat/new-auth (5 commits ahead):
+  gh pr create --head feat/new-auth --repo 42euge/geno-dev
+```
+
+**Stale branches (30+ days, no PR):**
+
+```
+Stale: chore/cleanup (60 days, 1 commit ahead) — open a PR or delete:
+  gh pr create --head chore/cleanup --repo 42euge/geno-dev
+  git -C <repo-path> branch -D chore/cleanup && git push origin --delete chore/cleanup
+```
+
+Only show action groups that have at least one branch.
+
+### 7. Overall summary
+
+Print a one-line summary per repo:
+
+```
+geno-dev: 6 branches — 1 needs PR, 2 open PRs (1 draft), 1 merged (cleanup), 1 stale, 1 no changes
+```
+
+If `--all` was used, add a combined summary across all repos.
+
+If there are PRs with `PR APPROVED` status, highlight them prominently:
+
+```
+Ready to merge: PR #52 (docs/improve-site) — approved, no conflicts
+```
+
+## Don'ts
+
+- Do NOT create, merge, close, or delete anything. This skill is strictly read-only — it audits and suggests, never mutates.
+- Do NOT fetch or pull. Work with whatever state is already local. If a branch exists only on the remote, use `origin/<branch>` refs.
+- Do NOT include the default branch (main/master) or `gh-pages` in the audit.
+- Do NOT show Claude Code worktrees (paths containing `/.claude/worktrees/`) — these are managed by Claude Code's isolation system.
+- Do NOT prompt the user for input during the audit. Run to completion and present results.

--- a/skills/geno-dev/SKILL.md
+++ b/skills/geno-dev/SKILL.md
@@ -8,7 +8,8 @@ description: >-
   Use when user says /geno-dev-tasks-start, /geno-dev-commits-rewrite,
   /geno-dev-worktrees-manage, /geno-dev-workspaces-init, /geno-dev-sessions-fork,
   /geno-dev-feature-ship, /geno-dev-issue-work, /geno-dev-loops-turbocharge,
-  /geno-dev-loops-cruise, /geno-dev-prs-check, or /geno-dev-scheduling-snooze.
+  /geno-dev-loops-cruise, /geno-dev-prs-check, /geno-dev-branches-audit,
+  or /geno-dev-scheduling-snooze.
 license: MIT
 metadata:
   author: 42euge
@@ -17,7 +18,7 @@ metadata:
 
 # geno-dev — Developer Utilities
 
-Dev and infrastructure skills for AI coding agents. Task execution, git history rewriting, worktree management, workspace creation, session forking, end-to-end feature shipping, issue-driven development, agentic loops, PR checking, and scheduled snoozing.
+Dev and infrastructure skills for AI coding agents. Task execution, git history rewriting, worktree management, workspace creation, session forking, end-to-end feature shipping, issue-driven development, agentic loops, PR checking, branch auditing, and scheduled snoozing.
 
 ## Commands
 
@@ -33,6 +34,7 @@ Dev and infrastructure skills for AI coding agents. Task execution, git history 
 | `/geno-dev-loops-turbocharge [task] [--spec <file>]` | Spec-driven convergence loop — iterate until all acceptance criteria pass |
 | `/geno-dev-loops-cruise [task] [--plan <file>]` | Plan-driven sequential loop — execute a plan one step at a time |
 | `/geno-dev-prs-check [repo\|--all]` | Check open PRs and flag ones that may need closing |
+| `/geno-dev-branches-audit [repo\|--all]` | Audit all branches — find ones needing PRs, ready to merge, or stale |
 | `/geno-dev-scheduling-snooze <time> [prompt]` | Snooze session until a specified time, then execute a prompt |
 
 ## Runtime


### PR DESCRIPTION
## Summary

- New skill `geno-dev-branches-audit` that audits all branches across a workspace or repo
- Classifies each branch by PR lifecycle status (NEEDS PR, PR OPEN, PR APPROVED, PR MERGED, STALE, etc.)
- Suggests copy-pasteable next actions (open PR, merge, delete stale branch)
- Complements `prs-check` (which starts from GitHub PRs) by starting from local branches/worktrees

## Test plan

- [ ] Invoke `/geno-dev-branches-audit` from a repo with multiple branches
- [ ] Verify it discovers local branches, worktree branches, and remote-only branches
- [ ] Confirm `gh pr list --head <branch> --state all` queries return correct classification
- [ ] Test `--all` flag from a multi-repo workspace
- [ ] Verify Claude Code worktree branches are excluded from output