### PR TITLE
Add skills-retro meta-harness

### DIFF
--- a/GENO.md
+++ b/GENO.md
@@ -19,6 +19,7 @@ Developer and infrastructure skills for AI coding agents: task execution from la
 | geno-dev-scheduling-snooze | scheduling | /geno-dev-scheduling-snooze |
 | geno-dev-feature-ship | feature-ship | /geno-dev-feature-ship |
 | geno-dev-issue-work | issue-work | /geno-dev-issue-work |
+| geno-dev-skills-retro | meta | /geno-dev-skills-retro |
 
 ## Repo structure
 
@@ -42,7 +43,8 @@ geno-dev/
 │   ├── geno-dev-branches-audit/
 │   ├── geno-dev-scheduling-snooze/
 │   ├── geno-dev-feature-ship/
-│   └── geno-dev-issue-work/
+│   ├── geno-dev-issue-work/
+│   └── geno-dev-skills-retro/
 ├── docs/                # MkDocs Material site
 │   ├── index.md
 │   ├── getting-started.md
@@ -70,6 +72,7 @@ Pure markdown skillset — no Python package, no venv, no scripts. Each skill is
 - **prs-check**: Checks open PRs, classifies by status (closeable/stale/blocked/draft/approved), renders a table with links.
 - **branches-audit**: Audits all branches across a workspace or repo, classifying by PR status and suggesting next actions.
 - **scheduling-snooze**: Delays session work until a specified time using natural language, with chained wakeups for long delays.
+- **skills-retro**: Meta-harness — analyzes failed sessions, identifies root causes, and patches the responsible skill to prevent recurrence.
 
 ## Conventions
 

--- a/skills/geno-dev-skills-retro/SKILL.md
+++ b/skills/geno-dev-skills-retro/SKILL.md
@@ -1,0 +1,315 @@
+---
+name: geno-dev-skills-retro
+description: >-
+  Meta-harness — analyze a failed session, identify root causes, and patch the
+  responsible skill to prevent the same failure. Self-improving skill loop.
+  Use when user says /geno-dev-skills-retro.
+argument-hint: "[session] [--skill <name>] [--dry-run]"
+license: MIT
+metadata:
+  author: 42euge
+  version: "0.1.0"
+---
+
+# Skills Retro
+
+Meta-harness for skill self-improvement. Reads a session transcript, identifies where the agent went wrong, traces the failure back to a skill deficiency, and generates a targeted patch to the skill's SKILL.md. The feedback loop: **session fails → retro finds the gap → skill gets patched → next session succeeds**.
+
+## Input
+
+Parse `$ARGUMENTS` for:
+
+- **Session** — session ID (partial match OK), PID number, or JSONL path (optional — defaults to most recent session in this project)
+- **`--skill <name>`** — skip auto-detection and target a specific skill for patching
+- **`--dry-run`** — analyze and propose changes but don't write them
+
+If no session is given, list the 5 most recent sessions for this project and ask the user to pick one.
+
+## When to Use
+
+- A session went sideways and you want to prevent the same failure next time
+- The user says "that didn't work" or "the skill keeps doing X wrong"
+- After a turbocharge/cruise loop stalled or failed
+- Periodic skill hygiene — retro the last N sessions to find recurring patterns
+
+Do **not** use for one-off user errors, infrastructure failures (API outage, network), or bugs in external tools.
+
+## Workflow
+
+### 1. Locate the transcript
+
+Resolve the session to a JSONL transcript file:
+
+```bash
+# List sessions for this project
+ls -lt ~/.claude/projects/$(pwd | tr '/' '-' | sed 's/^-//')/*.jsonl | head -5
+```
+
+Also check session metadata for context:
+
+```bash
+# Match session metadata by ID prefix
+python3 -c "
+import json, glob
+for f in glob.glob(os.path.expanduser('~/.claude/sessions/*.json')):
+    with open(f) as fh:
+        s = json.load(fh)
+        print(f'{s.get(\"pid\")} | {s.get(\"sessionId\",\"\")[:12]} | {s.get(\"name\",\"unnamed\")} | {s.get(\"cwd\",\"\")}')
+"
+```
+
+If the user gave a partial ID or PID, match it. If ambiguous, show candidates and ask.
+
+### 2. Parse the transcript
+
+Read the JSONL file and extract a structured timeline. Use a python script (inline) to parse:
+
+```python
+import json, sys
+
+timeline = []
+with open(sys.argv[1]) as f:
+    for i, line in enumerate(f):
+        obj = json.loads(line.strip())
+        t = obj.get('type')
+
+        if t == 'user':
+            msg = obj.get('message', {}).get('content', '')
+            # Detect skill invocations
+            is_skill = '<command-name>' in str(msg) or '<command-message>' in str(msg)
+            timeline.append({
+                'line': i, 'type': 'user', 'content': msg[:500],
+                'is_skill_invocation': is_skill
+            })
+
+        elif t == 'assistant':
+            blocks = obj.get('message', {}).get('content', '')
+            if isinstance(blocks, list):
+                for block in blocks:
+                    if isinstance(block, dict):
+                        if block.get('type') == 'tool_use':
+                            timeline.append({
+                                'line': i, 'type': 'tool_call',
+                                'tool': block.get('name'),
+                                'input_preview': str(block.get('input', {}))[:300]
+                            })
+                        elif block.get('type') == 'text':
+                            timeline.append({
+                                'line': i, 'type': 'assistant_text',
+                                'content': block['text'][:500]
+                            })
+
+        elif t == 'tool_result':
+            is_err = obj.get('is_error', False)
+            content = str(obj.get('content', ''))[:500]
+            timeline.append({
+                'line': i, 'type': 'tool_result',
+                'is_error': is_err, 'content': content
+            })
+
+json.dump(timeline, sys.stdout, indent=2)
+```
+
+Write the parsed timeline to `.geno/retro/<session-id>/timeline.json`.
+
+### 3. Identify failure signals
+
+Scan the timeline for these signal types, in order of strength:
+
+#### A. Hard failures (strongest signal)
+
+- **Tool errors**: `tool_result` entries with `is_error: true`
+- **Command failures**: Bash tool results containing non-zero exit codes, "command not found", "No such file", "Permission denied", stack traces
+- **Repeated retries**: Same tool called 3+ times with similar input (agent stuck in a loop)
+
+#### B. User corrections (strong signal)
+
+- **Explicit corrections**: User messages containing negation ("no", "not that", "wrong", "stop", "don't"), redirection ("instead", "actually", "what I meant"), or frustration markers ("again", "still", "keeps")
+- **Abandoned approaches**: User interrupts with a new instruction mid-workflow (the previous approach was failing)
+- **Manual takeover**: User provides the exact command or code to use (agent couldn't figure it out)
+
+#### C. Soft failures (weak signal — needs corroboration)
+
+- **Excessive tool calls**: More than 15 tool calls between user messages (thrashing)
+- **Context loss**: Agent re-reads the same file multiple times
+- **Stalled progress**: Long assistant text blocks with hedging language ("I'm not sure", "let me try", "this might")
+
+For each signal, record:
+- **Where**: line number in transcript
+- **What**: the failure event
+- **Context**: what the agent was trying to do (preceding user message + recent tool calls)
+
+Write findings to `.geno/retro/<session-id>/signals.md`.
+
+### 4. Trace to skill
+
+Determine which skill (if any) was active when the failure occurred:
+
+1. Scan for skill invocations in user messages (`<command-name>` tags or `/skill-name` patterns)
+2. Map each failure signal to the nearest preceding skill invocation
+3. If `--skill` was provided, filter to only signals relevant to that skill
+
+If no skill was invoked (plain conversation), check if the failure pattern *should* have been handled by an existing skill (e.g., agent tried to do manually what a skill automates). Flag this as a "missing skill trigger" issue.
+
+Read the identified skill's SKILL.md:
+
+```bash
+# Check installed location first, then repo
+cat ~/.agents/skills/<skill-name>/SKILL.md 2>/dev/null || \
+cat ./skills/<skill-name>/SKILL.md 2>/dev/null
+```
+
+### 5. Root cause analysis
+
+Classify each failure into one of these root cause categories:
+
+| Category | Description | Skill fix |
+|---|---|---|
+| **Missing guard** | Skill doesn't check a prerequisite that failed at runtime | Add a prerequisite check or "Step 0" validation |
+| **Wrong approach** | Skill prescribes method A but method B works for this case | Add conditional branch or replace approach |
+| **Missing edge case** | Skill handles the happy path but not this variant | Add handling to Error Recovery or a conditional in the workflow |
+| **Ambiguous instruction** | Skill's wording led the agent to misinterpret | Tighten the language, add an example or "Do NOT" entry |
+| **Missing context** | Skill doesn't tell the agent to gather needed information | Add a context-gathering step early in the workflow |
+| **Stale reference** | Skill references a tool, path, or API that changed | Update the reference |
+| **Missing skill** | No skill covers this workflow — agent improvised and failed | Recommend creating a new skill (don't patch an unrelated one) |
+
+Write the analysis to `.geno/retro/<session-id>/analysis.md`:
+
+```markdown
+# Retro Analysis — <session-id>
+
+## Session
+- ID: <session-id>
+- Project: <project path>
+- Date: <timestamp>
+- Skill(s) invoked: <list>
+
+## Failure Signals
+### Signal 1: <type>
+- **Line**: <n>
+- **What happened**: <description>
+- **Context**: <what was being attempted>
+
+## Root Causes
+### 1. <category>: <one-line summary>
+- **Evidence**: <which signals point to this>
+- **Skill**: <skill-name>
+- **Section**: <which part of the skill is deficient>
+- **Proposed fix**: <what to change>
+```
+
+### 6. Generate patch
+
+For each root cause that maps to an existing skill, generate a targeted edit:
+
+- Read the current SKILL.md content
+- Identify the exact section to modify (use line numbers)
+- Write the proposed change as an `old_string → new_string` diff
+- Keep changes minimal — add what's missing, don't rewrite working sections
+- Preserve the skill's existing voice and structure
+
+Present the patch to the user in a clear format:
+
+```markdown
+## Proposed Patch: <skill-name>/SKILL.md
+
+### Change 1: <summary>
+**Root cause**: <category> — <one-line>
+**Section**: <heading path, e.g., "Workflow > Step 3 > Execute">
+
+**Before:**
+> <existing text>
+
+**After:**
+> <proposed text>
+
+**Why**: <one sentence explaining how this prevents the failure>
+```
+
+If `--dry-run`, stop here. Otherwise, proceed to step 7.
+
+### 7. Apply (with confirmation)
+
+Use `AskUserQuestion` to confirm each change:
+
+- **Apply all** — write all proposed changes
+- **Apply selectively** — show each change and let the user accept/reject
+- **Save analysis only** — keep the retro artifacts but don't modify skills
+- **Discard** — this wasn't a skill issue
+
+For accepted changes, use the `Edit` tool to modify the skill's SKILL.md. Edit the **repo copy** (under `./skills/<name>/SKILL.md`) — the installed copy at `~/.agents/skills/` is a symlink or will be synced by `geno-tools update`.
+
+After applying:
+
+```bash
+geno-notes note "Skills retro: patched <skill-name> — <summary of changes>" \
+  --project --kind milestone 2>/dev/null || true
+```
+
+### 8. Log the retro
+
+Write a summary to `.geno/retro/<session-id>/retro.md`:
+
+```markdown
+# Retro Summary — <date>
+
+## Session: <session-id>
+## Skills patched: <list>
+## Changes applied: <count>
+
+### Patches
+1. **<skill>**: <one-line summary of change>
+   - Root cause: <category>
+   - Prevents: <what failure this addresses>
+
+## Patterns noticed
+<any recurring themes across this and previous retros — worth watching>
+```
+
+If this project has a geno-notes scope, also log the retro:
+
+```bash
+geno-notes note "Retro complete for session <id>: <n> patches applied to <skills>" \
+  --project --kind milestone 2>/dev/null || true
+```
+
+## Multi-Session Retro
+
+If the user says "retro the last N sessions" or provides multiple session IDs:
+
+1. Run steps 1–5 for each session independently
+2. Before step 6, cross-reference findings:
+   - **Recurring failures** — same root cause across sessions → higher priority patch
+   - **Contradictory signals** — one session says add X, another says remove X → flag for user
+   - **Cascade** — session B failed because session A's skill patch was incomplete → compound fix
+3. Deduplicate patches (don't propose the same edit twice)
+4. Present a unified patch set with frequency annotations ("seen in 3/5 sessions")
+
+## Feedback Memory Integration
+
+After a retro is applied, check if the root cause reveals a **user preference** or **project convention** that should be saved to memory:
+
+- If the failure was "agent used approach A but user always wants approach B" → this is a feedback memory, not just a skill patch. Save it so the preference applies across skills.
+- If the failure was "agent didn't know about project constraint X" → this is a project memory. Save it.
+
+Only save memories for patterns that transcend the specific skill being patched. Skill-specific fixes go in the skill file, not memory.
+
+## Error Recovery
+
+- If the transcript JSONL is malformed (truncated, corrupt), parse what you can and note the gap. A partial retro is better than none.
+- If the identified skill doesn't exist (was deleted or renamed), check git history: `git log --oneline --all -- 'skills/*<name>*'`. If found, note the rename. If not, classify as "missing skill."
+- If the user denies all patches, ask what they think the actual issue was. Their answer is valuable feedback — consider saving it as a feedback memory.
+- If `geno-notes` is not available, skip journaling steps — don't let journal failures block the retro.
+
+## What NOT to Do
+
+- **Don't patch skills for infrastructure failures.** API outages, network errors, and disk full are not skill bugs.
+- **Don't rewrite skills from scratch.** Retros produce targeted patches, not rewrites. If a skill needs a rewrite, that's a separate task.
+- **Don't infer failures that aren't there.** If the session succeeded, say so — not every session needs a patch.
+- **Don't modify the transcript.** Transcripts are immutable records. Analysis goes in `.geno/retro/`, not the JSONL.
+- **Don't apply patches without user confirmation** (unless `--auto` is explicitly passed — not in v0.1).
+- **Don't patch external tools.** If the failure is in `geno-notes`, `git`, or a test runner, note it but don't try to fix their code.
+
+## Runtime
+
+No venv or scripts — pure markdown workflow. Uses inline Python for transcript parsing. Retro artifacts live in `.geno/retro/<session-id>/`.

--- a/skills/geno-dev/SKILL.md
+++ b/skills/geno-dev/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   /geno-dev-worktrees-manage, /geno-dev-workspaces-init, /geno-dev-sessions-fork,
   /geno-dev-feature-ship, /geno-dev-issue-work, /geno-dev-loops-turbocharge,
   /geno-dev-loops-cruise, /geno-dev-prs-check, /geno-dev-branches-audit,
-  or /geno-dev-scheduling-snooze.
+  /geno-dev-scheduling-snooze, or /geno-dev-skills-retro.
 license: MIT
 metadata:
   author: 42euge
@@ -36,6 +36,7 @@ Dev and infrastructure skills for AI coding agents. Task execution, git history 
 | `/geno-dev-prs-check [repo\|--all]` | Check open PRs and flag ones that may need closing |
 | `/geno-dev-branches-audit [repo\|--all]` | Audit all branches — find ones needing PRs, ready to merge, or stale |
 | `/geno-dev-scheduling-snooze <time> [prompt]` | Snooze session until a specified time, then execute a prompt |
+| `/geno-dev-skills-retro [session] [--skill <name>]` | Meta-harness: analyze a failed session and patch the responsible skill |
 
 ## Runtime
 


### PR DESCRIPTION
## Summary
- New `geno-dev-skills-retro` skill — a meta-harness that closes the feedback loop on skill failures
- Parses session JSONL transcripts to identify failure signals (tool errors, user corrections, repeated retries, stalled progress)
- Traces failures back to the responsible skill, classifies root causes (missing guard, wrong approach, missing edge case, ambiguous instruction, stale reference, missing skill), and generates targeted SKILL.md patches
- Supports multi-session retro (cross-reference recurring patterns) and feedback memory integration
- Registered in umbrella `SKILL.md` and `GENO.md`

## Test plan
- [ ] Invoke `/geno-dev-skills-retro` on a known-failed session and verify it parses the transcript
- [ ] Confirm root cause classification produces actionable patch proposals
- [ ] Verify `--dry-run` mode analyzes without writing
- [ ] Verify `--skill <name>` filters to the target skill
- [ ] Confirm patches edit the repo copy under `./skills/`, not the installed symlink