### PR TITLE
Add /geno-dev-loops-ignition skill

### DIFF
--- a/GENO.md
+++ b/GENO.md
@@ -1,6 +1,6 @@
 # geno-dev — developer utilities skillset
 
-Developer and infrastructure skills for AI coding agents: task execution from lab notes, git commit history rewriting, worktree management, workspace creation, session forking, agentic loops, and scheduled snoozing.
+Developer and infrastructure skills for AI coding agents: task execution from lab notes, git commit history rewriting, worktree management, workspace creation, session forking, end-to-end feature shipping, issue-driven development, agentic loops, PR and branch auditing, scheduled snoozing, and skill retrospectives.
 
 ## Skills
 
@@ -14,6 +14,7 @@ Developer and infrastructure skills for AI coding agents: task execution from la
 | geno-dev-sessions-fork | sessions | /geno-dev-sessions-fork |
 | geno-dev-loops-turbocharge | loops | /geno-dev-loops-turbocharge |
 | geno-dev-loops-cruise | loops | /geno-dev-loops-cruise |
+| geno-dev-loops-ignition | loops | /geno-dev-loops-ignition |
 | geno-dev-prs-check | prs | /geno-dev-prs-check |
 | geno-dev-branches-audit | branches | /geno-dev-branches-audit |
 | geno-dev-scheduling-snooze | scheduling | /geno-dev-scheduling-snooze |
@@ -39,6 +40,7 @@ geno-dev/
 │   ├── geno-dev-worktrees-manage/
 │   ├── geno-dev-loops-turbocharge/
 │   ├── geno-dev-loops-cruise/
+│   ├── geno-dev-loops-ignition/
 │   ├── geno-dev-prs-check/
 │   ├── geno-dev-branches-audit/
 │   ├── geno-dev-scheduling-snooze/
@@ -69,6 +71,7 @@ Pure markdown skillset — no Python package, no venv, no scripts. Each skill is
 - **sessions-fork**: Extracts full session context via geno-mon for continuation in a new session.
 - **loops-turbocharge**: Spec-driven convergence loop — iterates until all acceptance criteria pass.
 - **loops-cruise**: Plan-driven sequential loop — executes a plan one step at a time via agent subagents.
+- **loops-ignition**: Cold-start bootstrap loop — turns a high-level goal into a blueprint, scaffold, implementation, and verified first slice.
 - **prs-check**: Checks open PRs, classifies by status (closeable/stale/blocked/draft/approved), renders a table with links.
 - **branches-audit**: Audits all branches across a workspace or repo, classifying by PR status and suggesting next actions.
 - **scheduling-snooze**: Delays session work until a specified time using natural language, with chained wakeups for long delays.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # geno-dev
 
-Developer and infrastructure skills for AI coding agents. Task execution from lab notes, git commit history rewriting, worktree management, workspace creation, session forking, agentic loops, and scheduled snoozing.
+Developer and infrastructure skills for AI coding agents. Task execution from lab notes, git commit history rewriting, worktree management, workspace creation, session forking, end-to-end feature shipping, issue-driven development, agentic loops, PR and branch auditing, scheduled snoozing, and skill retrospectives.
 
 ## Install
 
@@ -17,10 +17,15 @@ geno-tools install geno-dev
 | `/geno-dev-worktrees-manage [list\|create\|switch\|prune]` | Manage git worktrees — list, create, switch, and prune |
 | `/geno-dev-workspaces-init [config\|list\|<text>]` | Create development workspaces from issues, tickets, repos, or ideas |
 | `/geno-dev-sessions-fork [session]` | Fork an agent session — extract context to continue in a new session |
+| `/geno-dev-feature-ship [description\|issue URL]` | End-to-end: scope, issue, branch, implement, and PR |
+| `/geno-dev-issue-work [number\|query\|URL]` | Pick a GitHub issue or JIRA ticket and work on it (normal or loop mode) |
 | `/geno-dev-loops-turbocharge [task] [--spec <file>]` | Spec-driven convergence loop — iterate until all acceptance criteria pass |
 | `/geno-dev-loops-cruise [task] [--plan <file>]` | Plan-driven sequential loop — execute a plan one step at a time |
+| `/geno-dev-loops-ignition [goal] [--blueprint <file>]` | Cold-start bootstrap loop — turn a high-level goal into a blueprint and verified first slice |
 | `/geno-dev-prs-check [repo\|--all]` | Check open PRs and flag ones that may need closing |
+| `/geno-dev-branches-audit [repo\|--all]` | Audit all branches — find ones needing PRs, ready to merge, or stale |
 | `/geno-dev-scheduling-snooze <time> [prompt]` | Snooze session until a specified time, then execute a prompt |
+| `/geno-dev-skills-retro [session] [--skill <name>]` | Meta-harness: analyze a failed session and patch the responsible skill |
 
 ## Repository structure
 
@@ -48,9 +53,19 @@ geno-dev/
 │   │   └── SKILL.md
 │   ├── geno-dev-loops-cruise/
 │   │   └── SKILL.md
+│   ├── geno-dev-loops-ignition/
+│   │   └── SKILL.md
 │   ├── geno-dev-prs-check/
 │   │   └── SKILL.md
-│   └── geno-dev-scheduling-snooze/
+│   ├── geno-dev-branches-audit/
+│   │   └── SKILL.md
+│   ├── geno-dev-scheduling-snooze/
+│   │   └── SKILL.md
+│   ├── geno-dev-feature-ship/
+│   │   └── SKILL.md
+│   ├── geno-dev-issue-work/
+│   │   └── SKILL.md
+│   └── geno-dev-skills-retro/
 │       └── SKILL.md
 ├── docs/
 │   ├── index.md

--- a/SKILL.md
+++ b/SKILL.md
@@ -3,9 +3,15 @@ name: geno-dev
 description: >-
   Developer and infrastructure utilities — task execution from lab notes,
   git commit history rewriting, worktree management, workspace creation,
-  and session forking.
+  session forking, end-to-end feature shipping, issue-driven development,
+  agentic loops, PR auditing, branch auditing, scheduled snoozing, and
+  skill retrospectives.
   Use when user says /geno-dev-tasks-start, /geno-dev-commits-rewrite,
-  /geno-dev-worktrees-manage, /geno-dev-workspaces-init, or /geno-dev-sessions-fork.
+  /geno-dev-worktrees-manage, /geno-dev-workspaces-init, /geno-dev-sessions-fork,
+  /geno-dev-feature-ship, /geno-dev-issue-work, /geno-dev-loops-turbocharge,
+  /geno-dev-loops-cruise, /geno-dev-loops-ignition, /geno-dev-prs-check,
+  /geno-dev-branches-audit, /geno-dev-scheduling-snooze, or
+  /geno-dev-skills-retro.
 license: MIT
 metadata:
   author: 42euge
@@ -14,7 +20,7 @@ metadata:
 
 # geno-dev — Developer Utilities
 
-Dev and infrastructure skills for AI coding agents. Task execution, git history rewriting, worktree management, workspace creation, and session forking.
+Dev and infrastructure skills for AI coding agents. Task execution, git history rewriting, worktree management, workspace creation, session forking, end-to-end feature shipping, issue-driven development, agentic loops, PR auditing, branch auditing, scheduled snoozing, and skill retrospectives.
 
 ## Commands
 
@@ -25,6 +31,15 @@ Dev and infrastructure skills for AI coding agents. Task execution, git history 
 | `/geno-dev-worktrees-manage [list\|create\|switch\|prune]` | Manage git worktrees — list, create, switch, and prune |
 | `/geno-dev-workspaces-init [config\|list\|<text>]` | Create development workspaces from issues, tickets, repos, or ideas |
 | `/geno-dev-sessions-fork [session]` | Fork an agent session — extract context to continue in a new session |
+| `/geno-dev-feature-ship [description\|issue URL]` | End-to-end: scope, issue, branch, implement, and PR |
+| `/geno-dev-issue-work [number\|query\|URL]` | Pick a GitHub issue or JIRA ticket and work on it (normal or loop mode) |
+| `/geno-dev-loops-turbocharge [task] [--spec <file>]` | Spec-driven convergence loop — iterate until all acceptance criteria pass |
+| `/geno-dev-loops-cruise [task] [--plan <file>]` | Plan-driven sequential loop — execute a plan one step at a time |
+| `/geno-dev-loops-ignition [goal] [--blueprint <file>]` | Cold-start bootstrap loop — turn a high-level goal into a blueprint and verified first slice |
+| `/geno-dev-prs-check [repo\|--all]` | Check open PRs and flag ones that may need closing |
+| `/geno-dev-branches-audit [repo\|--all]` | Audit all branches — find ones needing PRs, ready to merge, or stale |
+| `/geno-dev-scheduling-snooze <time> [prompt]` | Snooze session until a specified time, then execute a prompt |
+| `/geno-dev-skills-retro [session] [--skill <name>]` | Meta-harness: analyze a failed session and patch the responsible skill |
 
 ## Runtime
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -224,6 +224,41 @@ If no plan is provided, checks `geno-notes plans/` for the task's plan, then ask
 
 ---
 
+## Ignition Loop
+
+**`/geno-dev-loops-ignition [goal] [--blueprint <file>] [--max <n>]`**
+
+Cold-start bootstrap loop. Takes a high-level goal, generates or loads a blueprint, then bootstraps the work in layers: structure, implementation, and verification.
+
+### Input
+
+- A high-level goal to bootstrap
+- An optional task pattern to fuzzy-match against geno-notes tasks
+- `--blueprint <file>` — start from an existing blueprint instead of generating one
+- `--max <n>` — maximum layers or iterations (default: 6)
+
+If no goal or blueprint is provided, the skill asks the user for one.
+
+### Workflow
+
+1. **Load or create task context** — finds or creates a geno-notes task, starts it, and creates a session directory at `.geno/loops/ignition/<timestamp>/`
+2. **Generate blueprint** — inspects the issue, repo, and constraints, then writes a living blueprint with deliverables, structure, layers, and verification plan
+3. **Pick next layer** — chooses the thinnest meaningful layer to bootstrap next, avoiding broad over-scaffolding
+4. **Scaffold** — a Scaffolder role creates the minimum structure and writes a checkpoint
+5. **Build** — a Builder role fills in the scaffold with a coherent first implementation and writes a checkpoint
+6. **Verify** — a Verifier role runs the lightest meaningful validation, records evidence, and recommends the next layer
+7. **Evolve blueprint** — updates the blueprint and session log with what became concrete during the layer
+8. **Loop or complete** — continues until there is a verified first slice or the max layer count is reached
+
+### Best Fit
+
+Use Ignition when you're starting from a rough goal and need the first working slice to take shape. If you already have a numbered plan, use Cruise. If you already have a testable spec, use Turbocharge.
+
+!!! tip
+    A good Ignition prompt is short and outcome-oriented: `/geno-dev-loops-ignition bootstrap a new skill for parsing deployment logs` is enough to start with blueprint generation.
+
+---
+
 ## Check PRs
 
 **`/geno-dev-prs-check [repo|--all]`**

--- a/genotools.yaml
+++ b/genotools.yaml
@@ -3,4 +3,4 @@ version: "0.1.0"
 description: >-
   Developer and infrastructure utilities — task execution from lab notes,
   git commit history rewriting, worktree management, workspace creation,
-  and session forking.
+  session forking, issue-driven development, and agentic loops.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "geno-dev",
   "version": "0.1.0",
-  "description": "Developer utilities — task execution, commit rewriting, worktree management, workspace creation, agentic loops",
+  "description": "Developer utilities — task execution, commit rewriting, worktree and workspace management, issue-driven development, and agentic loops",
   "skills": {
     "geno-dev": "skills/geno-dev"
   },

--- a/skills/geno-dev-loops-ignition/SKILL.md
+++ b/skills/geno-dev-loops-ignition/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: geno-dev-loops-ignition
+description: >-
+  Cold-start bootstrap loop — turn a high-level goal into a blueprint,
+  scaffold, implementation, and verification cycle.
+  Use when user says /geno-dev-loops-ignition.
+argument-hint: "[goal] [--blueprint <file>] [--max <n>]"
+license: MIT
+metadata:
+  author: 42euge
+  version: "0.1.0"
+---
+
+# Ignition Loop
+
+Cold-start bootstrap loop. Takes a high-level goal, generates or loads a blueprint, then iteratively bootstraps the work in layers: structure -> implementation -> verification. Each layer hands off checkpoints between Scaffolder, Builder, and Verifier roles so the plan can evolve as the repo takes shape.
+
+## Input
+
+Parse `$ARGUMENTS` for:
+
+- **Task pattern** — fuzzy-matches against geno-notes tasks (optional)
+- **Goal text** — a freeform description of what to bootstrap
+- **`--blueprint <file>`** — start from an existing blueprint instead of generating one
+- **`--max <n>`** — maximum layers or iterations (default: 6)
+
+If no task pattern or goal is provided, use `AskUserQuestion` to ask the user for one of:
+1. A high-level goal
+2. A blueprint file path
+3. "Start from current issue/task"
+
+## When to Use
+
+- Starting a new project, package, module, or feature branch from a rough goal
+- Bootstrapping structure before detailed specs exist
+- Standing up the first vertical slice: skeleton, core implementation, and verification harness
+- Turning an issue brief into an executable blueprint
+
+Do **not** use when a spec already exists (use Turbocharge), when a step-by-step plan already exists (use Cruise), or when the work is mostly exploratory research (use Drift).
+
+## Workflow
+
+### 1. Load or create task context
+
+- Check for geno-notes project scope: `geno-notes list --project --status active --json`
+- If a task pattern was provided, activate it: `geno-notes start <pattern> --project`
+- If no active task matches and the user gave a goal, create one: `geno-notes add "<goal>" --project`
+- Start or activate the task so milestones attach to it
+- Create session directory:
+  ```
+  .geno/loops/ignition/<YYYYMMDD-HHMM>/
+  ├── session.md
+  ├── goal.md
+  ├── blueprint.md
+  ├── layers/
+  │   ├── layer_01.md
+  │   └── ...
+  └── checkpoints/
+      ├── layer_01_scaffolder.md
+      ├── layer_01_builder.md
+      └── layer_01_verifier.md
+  ```
+- Write `session.md` header:
+  ```markdown
+  # Ignition Session — <YYYY-MM-DD HH:MM>
+  ## Config
+  - Task: <geno-notes task id or "none">
+  - Goal: <summary>
+  - Blueprint: <generated or file path>
+  - Max layers: <n>
+
+  ## Log
+  ```
+
+### 2. Generate or load blueprint
+
+- If `--blueprint <file>` was provided, copy it into `blueprint.md`
+- Otherwise inspect the repo, issue, and constraints, then write a blueprint containing:
+  - Objective and non-goals
+  - Deliverables
+  - Proposed structure (directories, files, entrypoints, interfaces)
+  - Implementation slices or layers
+  - Verification plan
+  - Open questions and assumptions
+- Save the normalized goal in `goal.md`
+- Record the first log entry in `session.md`
+
+### 3. Pick the next bootstrap layer
+
+Sequence work from lowest-friction foundation to first usable slice:
+
+1. **Structure** — folders, files, entrypoints, interfaces, placeholders
+2. **Implementation** — enough working code or content to make the layer real
+3. **Verification** — tests, lint/build integration, manual checks, docs updates
+
+Choose the smallest layer that meaningfully advances the blueprint without over-scaffolding. Write `layers/layer_<n>.md` with the target, files, verification method, and handoff notes.
+
+### 4. Scaffold the layer
+
+- Spawn a **Scaffolder** agent with the blueprint, current layer file, and previous verifier checkpoint
+- Scaffolder creates or reorganizes the minimal structure needed for the layer and writes `checkpoints/layer_<n>_scaffolder.md`:
+  ```markdown
+  # Layer <n> Scaffolder
+  ## Structure created
+  ## Files touched
+  ## Assumptions
+  ## Handoff to Builder
+  ```
+- If scaffolding reveals a better structure, update `blueprint.md` before continuing
+
+### 5. Build the layer
+
+- Spawn a **Builder** agent with the blueprint, layer file, and scaffolder checkpoint
+- Builder fills in the scaffold with the smallest coherent implementation that makes the layer usable
+- Builder writes `checkpoints/layer_<n>_builder.md`:
+  ```markdown
+  # Layer <n> Builder
+  ## What was implemented
+  ## Files modified
+  ## Remaining gaps
+  ## Handoff to Verifier
+  ```
+
+### 6. Verify the layer
+
+- Spawn a **Verifier** agent with the blueprint, layer file, and builder checkpoint
+- Verifier runs the lightest meaningful validation for the layer:
+
+| Layer type | Verification examples |
+|---|---|
+| Structure | File tree check, import smoke test, command help output |
+| Implementation | Focused test, type check, local run, fixture execution |
+| Verification/docs | Full test target, lint, docs link spot-check |
+
+- Verifier writes `checkpoints/layer_<n>_verifier.md` with pass/fail, evidence, remaining gaps, and the recommended next layer
+- Log milestone:
+  ```bash
+  geno-notes note "Ignition layer <n> complete: <summary>" --task <id> --kind milestone --project
+  ```
+
+### 7. Evolve the blueprint
+
+Update `blueprint.md` and `session.md` with what became concrete:
+
+- Completed layers
+- Decisions discovered during implementation
+- Remaining layers
+- Scope cuts or new risks
+
+Treat the blueprint as a living build sheet, not a frozen spec.
+
+### 8. Loop or complete
+
+**If the goal has a usable scaffold plus first verified slice:**
+1. Write final summary to `session.md`
+2. Log completion: `geno-notes note "Ignition complete: first verified slice bootstrapped" --task <id> --kind milestone --project`
+3. If the task is fully done: `geno-notes done <id> --project`
+4. Stop the loop
+
+**If work remains and layers < max:**
+1. Call `ScheduleWakeup` with delay 90-180 seconds
+2. On wake, repeat from step 3
+
+**If max layers reached:**
+1. Write summary to `session.md` with current scaffold, completed layers, and recommended next layer
+2. Log: `geno-notes note "Ignition stopped at max layers: <n>/<max> complete" --task <id> --kind note --project`
+3. Report what exists, what is next, and where to resume
+4. Stop the loop
+
+## Error Recovery
+
+- If the blueprint is too vague to pick a first layer, stop and ask the user for a narrower goal.
+- If Scaffolder, Builder, and Verifier disagree on structure, resolve it in `blueprint.md` before starting the next layer.
+- If a verification step fails because the harness does not exist yet, treat building that harness as the next layer instead of forcing a broken check.
+- If two consecutive layers add only placeholders without producing a usable slice, reduce scope and bootstrap a thinner vertical path.
+- If `geno-notes` CLI fails, continue the loop and log the journal failure in `session.md`.
+- Never do destructive git operations or mass deletions of generated structure without explicit user confirmation.
+
+## What NOT to Do
+
+- **Don't start coding without a blueprint.** Ignition is spec-generating; the blueprint is the contract for the next layers.
+- **Don't scaffold the whole project upfront.** Build only the next few layers needed to reach a verified slice.
+- **Don't freeze the blueprint.** Update it when the repo teaches you something new.
+- **Don't confuse placeholders with completion.** Every layer should end with something checkable.
+- **Don't use Ignition when the work already has a detailed plan or test suite.** Prefer Cruise or Turbocharge in those cases.
+
+## Runtime
+
+No venv or scripts — pure markdown workflow. Uses Agent subagents for role handoffs and `ScheduleWakeup` for self-pacing within `/loop`.

--- a/skills/geno-dev/SKILL.md
+++ b/skills/geno-dev/SKILL.md
@@ -4,12 +4,14 @@ description: >-
   Developer and infrastructure utilities — task execution from lab notes,
   git commit history rewriting, worktree management, workspace creation,
   session forking, end-to-end feature shipping, issue-driven development,
-  agentic loops, and scheduled snoozing.
+  agentic loops, PR checking, branch auditing, scheduled snoozing, and
+  skill retrospectives.
   Use when user says /geno-dev-tasks-start, /geno-dev-commits-rewrite,
   /geno-dev-worktrees-manage, /geno-dev-workspaces-init, /geno-dev-sessions-fork,
   /geno-dev-feature-ship, /geno-dev-issue-work, /geno-dev-loops-turbocharge,
-  /geno-dev-loops-cruise, /geno-dev-prs-check, /geno-dev-branches-audit,
-  /geno-dev-scheduling-snooze, or /geno-dev-skills-retro.
+  /geno-dev-loops-cruise, /geno-dev-loops-ignition, /geno-dev-prs-check,
+  /geno-dev-branches-audit, /geno-dev-scheduling-snooze, or
+  /geno-dev-skills-retro.
 license: MIT
 metadata:
   author: 42euge
@@ -18,7 +20,7 @@ metadata:
 
 # geno-dev — Developer Utilities
 
-Dev and infrastructure skills for AI coding agents. Task execution, git history rewriting, worktree management, workspace creation, session forking, end-to-end feature shipping, issue-driven development, agentic loops, PR checking, branch auditing, and scheduled snoozing.
+Dev and infrastructure skills for AI coding agents. Task execution, git history rewriting, worktree management, workspace creation, session forking, end-to-end feature shipping, issue-driven development, agentic loops, PR checking, branch auditing, scheduled snoozing, and skill retrospectives.
 
 ## Commands
 
@@ -33,6 +35,7 @@ Dev and infrastructure skills for AI coding agents. Task execution, git history 
 | `/geno-dev-issue-work [number\|query\|URL]` | Pick a GitHub issue or JIRA ticket and work on it (normal or loop mode) |
 | `/geno-dev-loops-turbocharge [task] [--spec <file>]` | Spec-driven convergence loop — iterate until all acceptance criteria pass |
 | `/geno-dev-loops-cruise [task] [--plan <file>]` | Plan-driven sequential loop — execute a plan one step at a time |
+| `/geno-dev-loops-ignition [goal] [--blueprint <file>]` | Cold-start bootstrap loop — turn a high-level goal into a blueprint and verified first slice |
 | `/geno-dev-prs-check [repo\|--all]` | Check open PRs and flag ones that may need closing |
 | `/geno-dev-branches-audit [repo\|--all]` | Audit all branches — find ones needing PRs, ready to merge, or stale |
 | `/geno-dev-scheduling-snooze <time> [prompt]` | Snooze session until a specified time, then execute a prompt |


### PR DESCRIPTION
## Summary
- add the new `geno-dev-loops-ignition` cold-start bootstrap loop skill
- register the new loop across umbrella manifests and repo docs
- sync touched metadata/README command tables with the current skill surface

## Verification
- `git diff --check`
- repo-wide search for `geno-dev-loops-ignition`

Closes #15