### PR TITLE
Add Autopilot background monitoring loop

### DIFF
--- a/GENO.md
+++ b/GENO.md
@@ -1,6 +1,6 @@
 # geno-dev — developer utilities skillset
 
-Developer and infrastructure skills for AI coding agents: task execution from lab notes, git commit history rewriting, worktree management, workspace creation, session forking, agentic loops, and scheduled snoozing.
+Developer and infrastructure skills for AI coding agents: task execution from lab notes, git commit history rewriting, worktree management, workspace creation, session forking, issue-driven development, agentic loops, background monitoring, and scheduled snoozing.
 
 ## Skills
 
@@ -14,6 +14,7 @@ Developer and infrastructure skills for AI coding agents: task execution from la
 | geno-dev-sessions-fork | sessions | /geno-dev-sessions-fork |
 | geno-dev-loops-turbocharge | loops | /geno-dev-loops-turbocharge |
 | geno-dev-loops-cruise | loops | /geno-dev-loops-cruise |
+| geno-dev-loops-autopilot | loops | /geno-dev-loops-autopilot |
 | geno-dev-prs-check | prs | /geno-dev-prs-check |
 | geno-dev-branches-audit | branches | /geno-dev-branches-audit |
 | geno-dev-scheduling-snooze | scheduling | /geno-dev-scheduling-snooze |
@@ -38,6 +39,7 @@ geno-dev/
 │   ├── geno-dev-worktrees-manage/
 │   ├── geno-dev-loops-turbocharge/
 │   ├── geno-dev-loops-cruise/
+│   ├── geno-dev-loops-autopilot/
 │   ├── geno-dev-prs-check/
 │   ├── geno-dev-branches-audit/
 │   ├── geno-dev-scheduling-snooze/
@@ -65,8 +67,11 @@ Pure markdown skillset — no Python package, no venv, no scripts. Each skill is
 - **worktrees-manage**: Workspace-aware git worktree management with safety protections for Claude Code and geno-tools worktrees.
 - **workspaces-init**: Creates isolated development workspaces from GitHub issues, JIRA tickets, repo names, or feature ideas, with color-coded folder organization.
 - **sessions-fork**: Extracts full session context via geno-mon for continuation in a new session.
+- **feature-ship**: Takes a feature from scoped idea or issue through implementation and PR creation.
+- **issue-work**: Selects a GitHub issue or JIRA ticket, sets up a branch or worktree, and executes it in normal or loop mode.
 - **loops-turbocharge**: Spec-driven convergence loop — iterates until all acceptance criteria pass.
 - **loops-cruise**: Plan-driven sequential loop — executes a plan one step at a time via agent subagents.
+- **loops-autopilot**: Background monitoring loop — watches CI, tests, lint, and git state, auto-fixing low-risk issues or alerting when needed.
 - **prs-check**: Checks open PRs, classifies by status (closeable/stale/blocked/draft/approved), renders a table with links.
 - **branches-audit**: Audits all branches across a workspace or repo, classifying by PR status and suggesting next actions.
 - **scheduling-snooze**: Delays session work until a specified time using natural language, with chained wakeups for long delays.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # geno-dev
 
-Developer and infrastructure skills for AI coding agents. Task execution from lab notes, git commit history rewriting, worktree management, workspace creation, session forking, agentic loops, and scheduled snoozing.
+Developer and infrastructure skills for AI coding agents. Task execution from lab notes, git commit history rewriting, worktree management, workspace creation, session forking, issue-driven development, agentic loops, background monitoring, and scheduled snoozing.
 
 ## Install
 
@@ -17,9 +17,13 @@ geno-tools install geno-dev
 | `/geno-dev-worktrees-manage [list\|create\|switch\|prune]` | Manage git worktrees — list, create, switch, and prune |
 | `/geno-dev-workspaces-init [config\|list\|<text>]` | Create development workspaces from issues, tickets, repos, or ideas |
 | `/geno-dev-sessions-fork [session]` | Fork an agent session — extract context to continue in a new session |
+| `/geno-dev-feature-ship [description\|issue URL]` | End-to-end: scope, issue, branch, implement, and PR |
+| `/geno-dev-issue-work [number\|query\|URL]` | Pick a GitHub issue or JIRA ticket and work on it (normal or loop mode) |
 | `/geno-dev-loops-turbocharge [task] [--spec <file>]` | Spec-driven convergence loop — iterate until all acceptance criteria pass |
 | `/geno-dev-loops-cruise [task] [--plan <file>]` | Plan-driven sequential loop — execute a plan one step at a time |
+| `/geno-dev-loops-autopilot [task] [--watch <tests\|ci\|lint\|git\|all>]` | Background monitoring loop — watch CI, tests, lint, and git state |
 | `/geno-dev-prs-check [repo\|--all]` | Check open PRs and flag ones that may need closing |
+| `/geno-dev-branches-audit [repo\|--all]` | Audit all branches — find ones needing PRs, ready to merge, or stale |
 | `/geno-dev-scheduling-snooze <time> [prompt]` | Snooze session until a specified time, then execute a prompt |
 
 ## Repository structure
@@ -48,7 +52,15 @@ geno-dev/
 │   │   └── SKILL.md
 │   ├── geno-dev-loops-cruise/
 │   │   └── SKILL.md
+│   ├── geno-dev-loops-autopilot/
+│   │   └── SKILL.md
 │   ├── geno-dev-prs-check/
+│   │   └── SKILL.md
+│   ├── geno-dev-branches-audit/
+│   │   └── SKILL.md
+│   ├── geno-dev-feature-ship/
+│   │   └── SKILL.md
+│   ├── geno-dev-issue-work/
 │   │   └── SKILL.md
 │   └── geno-dev-scheduling-snooze/
 │       └── SKILL.md

--- a/SKILL.md
+++ b/SKILL.md
@@ -3,9 +3,14 @@ name: geno-dev
 description: >-
   Developer and infrastructure utilities — task execution from lab notes,
   git commit history rewriting, worktree management, workspace creation,
-  and session forking.
+  session forking, end-to-end feature shipping, issue-driven development,
+  agentic loops, background monitoring, PR checking, branch auditing,
+  and scheduled snoozing.
   Use when user says /geno-dev-tasks-start, /geno-dev-commits-rewrite,
-  /geno-dev-worktrees-manage, /geno-dev-workspaces-init, or /geno-dev-sessions-fork.
+  /geno-dev-worktrees-manage, /geno-dev-workspaces-init, /geno-dev-sessions-fork,
+  /geno-dev-feature-ship, /geno-dev-issue-work, /geno-dev-loops-turbocharge,
+  /geno-dev-loops-cruise, /geno-dev-loops-autopilot, /geno-dev-prs-check,
+  /geno-dev-branches-audit, or /geno-dev-scheduling-snooze.
 license: MIT
 metadata:
   author: 42euge
@@ -14,7 +19,7 @@ metadata:
 
 # geno-dev — Developer Utilities
 
-Dev and infrastructure skills for AI coding agents. Task execution, git history rewriting, worktree management, workspace creation, and session forking.
+Dev and infrastructure skills for AI coding agents. Task execution, git history rewriting, worktree management, workspace creation, session forking, end-to-end feature shipping, issue-driven development, agentic loops, background monitoring, PR checking, branch auditing, and scheduled snoozing.
 
 ## Commands
 
@@ -25,6 +30,14 @@ Dev and infrastructure skills for AI coding agents. Task execution, git history 
 | `/geno-dev-worktrees-manage [list\|create\|switch\|prune]` | Manage git worktrees — list, create, switch, and prune |
 | `/geno-dev-workspaces-init [config\|list\|<text>]` | Create development workspaces from issues, tickets, repos, or ideas |
 | `/geno-dev-sessions-fork [session]` | Fork an agent session — extract context to continue in a new session |
+| `/geno-dev-feature-ship [description\|issue URL]` | End-to-end: scope, issue, branch, implement, and PR |
+| `/geno-dev-issue-work [number\|query\|URL]` | Pick a GitHub issue or JIRA ticket and work on it (normal or loop mode) |
+| `/geno-dev-loops-turbocharge [task] [--spec <file>]` | Spec-driven convergence loop — iterate until all acceptance criteria pass |
+| `/geno-dev-loops-cruise [task] [--plan <file>]` | Plan-driven sequential loop — execute a plan one step at a time |
+| `/geno-dev-loops-autopilot [task] [--watch <tests\|ci\|lint\|git\|all>]` | Background monitoring loop — watch CI, tests, lint, and git state |
+| `/geno-dev-prs-check [repo\|--all]` | Check open PRs and flag ones that may need closing |
+| `/geno-dev-branches-audit [repo\|--all]` | Audit all branches — find ones needing PRs, ready to merge, or stale |
+| `/geno-dev-scheduling-snooze <time> [prompt]` | Snooze session until a specified time, then execute a prompt |
 
 ## Runtime
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -160,6 +160,70 @@ Workspace settings at `~/.geno/config.yaml` (auto-created on first use):
 
 ---
 
+## Ship Feature
+
+**`/geno-dev-feature-ship [description|issue URL]`**
+
+Take a feature idea from scoping through implementation to a pull request.
+
+### Input
+
+- A freeform feature description
+- An existing GitHub issue URL
+
+If no argument is provided, the skill asks what the user wants to build.
+
+### Workflow
+
+1. **Scope the feature** — clarify requirements with the user, or fetch the linked GitHub issue
+2. **Create the issue** — draft and create a GitHub issue when starting from a freeform idea
+3. **Create the branch** — branch from the default branch with a descriptive name
+4. **Implement** — explore, plan if needed, code, document, and verify
+5. **Open the PR** — create a pull request that links back to the issue
+6. **Wrap up** — summarize what shipped and note any follow-up scope
+
+!!! tip
+    Use this when the work starts as an idea. If the issue already exists and you want to execute it directly, use `/geno-dev-issue-work`.
+
+**See also:** [Issue to PR workflow](workflows.md#issue-to-pr)
+
+---
+
+## Work on Issue
+
+**`/geno-dev-issue-work [number|query|URL]`**
+
+Pick a GitHub issue or JIRA ticket and execute it with either interactive or autonomous flow.
+
+### Input
+
+- A GitHub issue number
+- A JIRA key like `PROJ-1234`
+- A GitHub or JIRA URL
+- A search query for finding the issue
+
+### Workflow
+
+1. **Detect source** — determine GitHub vs. JIRA from the argument
+2. **Select the issue** — fetch directly or search and let the user choose
+3. **Read context** — summarize the issue body, constraints, and comments
+4. **Choose execution mode** — normal interactive mode or autonomous loop mode
+5. **Choose workspace strategy** — worktree or in-place
+6. **Create the branch** — branch from the default branch using the issue number or ticket key
+7. **Implement and ship** — do the work, verify it, and open the PR
+
+### Modes
+
+- **Normal mode** — interactive back-and-forth, best for ambiguous work
+- **Loop mode** — autonomous execution with periodic check-ins, best for well-defined work
+
+!!! tip
+    Prefer a separate worktree when your current checkout is dirty or you want parallel issue work without disturbing the main clone.
+
+**See also:** [Issue to PR workflow](workflows.md#issue-to-pr) · [Manage Worktrees](#manage-worktrees)
+
+---
+
 ## Turbocharge Loop
 
 **`/geno-dev-loops-turbocharge [task] [--spec <file>] [--max <n>]`**
@@ -221,6 +285,39 @@ If no plan is provided, checks `geno-notes plans/` for the task's plan, then ask
 
 !!! tip
     Pairs well with plan mode: use `/geno-dev-tasks-start` to plan a complex task, then run `/geno-dev-loops-cruise --plan geno/geno-notes/plans/<task>.md` to execute it.
+
+---
+
+## Autopilot Loop
+
+**`/geno-dev-loops-autopilot [task] [--watch <tests|ci|lint|git|all>] [--every <15m|30m>] [--for <duration>]`**
+
+Background monitoring loop. Watches a branch or PR over a long window and reacts to regressions or maintenance opportunities.
+
+### Input
+
+- A task pattern to match against geno-notes (optional)
+- `--watch <tests|ci|lint|git|all>` — which signals to monitor
+- `--every <15m|30m>` — how often to wake up
+- `--for <duration>` — total monitoring window, up to the `CronCreate` 7-day limit
+
+### Workflow
+
+1. **Load context** — detect repo, branch, PR context, active task, and create `.geno/loops/autopilot/<timestamp>/`
+2. **Capture baseline** — record current test, lint, CI, and git state for the chosen watch set
+3. **Schedule monitoring** — use `CronCreate` for 15–30 minute recurring checks
+4. **React on each cycle** — re-check signals, retry transient failures once, apply safe deterministic fixes, or escalate
+5. **Journal outcomes** — log cycles to `session.md` and write bug notes, milestones, or follow-up tasks via geno-notes
+6. **Stop cleanly** — finish when the duration expires, the PR merges, or a human decision is needed
+
+### Safe auto-fixes
+
+- Formatter or lint autofix commands with immediate verification
+- Deterministic generated-file refreshes for repos that already track generated outputs
+- A single retry for likely transient CI or test failures
+
+!!! tip
+    Autopilot is for low-intensity background maintenance. If the work turns into active implementation, switch to Turbocharge or Cruise.
 
 ---
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,6 +1,6 @@
 # Concepts
 
-geno-dev provides five skills that form a development lifecycle. This page explains the key abstractions and how they connect.
+geno-dev provides a set of skills that form a development lifecycle. This page explains the key abstractions and how they connect.
 
 ## The Development Lifecycle
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # geno-dev
 
-Developer and infrastructure skills for AI coding agents. Task execution from lab notes, git commit history rewriting, worktree management, workspace creation, and session forking.
+Developer and infrastructure skills for AI coding agents. Task execution from lab notes, git commit history rewriting, worktree management, workspace creation, issue-driven development, agentic loops, and session forking.
 
 Part of the [geno-tools](https://42euge.github.io/geno-tools) ecosystem.
 
@@ -25,6 +25,14 @@ Or from within an agent session:
 | `/geno-dev-worktrees-manage [list\|create\|switch\|prune]` | Manage git worktrees -- list, create, switch, and prune |
 | `/geno-dev-workspaces-init [config\|list\|<text>]` | Create development workspaces from issues, tickets, repos, or ideas |
 | `/geno-dev-sessions-fork [session]` | Fork an agent session — extract context to continue in a new session |
+| `/geno-dev-feature-ship [description\|issue URL]` | End-to-end: scope, issue, branch, implement, and PR |
+| `/geno-dev-issue-work [number\|query\|URL]` | Pick a GitHub issue or JIRA ticket and work on it (normal or loop mode) |
+| `/geno-dev-loops-turbocharge [task] [--spec <file>]` | Spec-driven convergence loop — iterate until all acceptance criteria pass |
+| `/geno-dev-loops-cruise [task] [--plan <file>]` | Plan-driven sequential loop — execute a plan one step at a time |
+| `/geno-dev-loops-autopilot [task] [--watch <tests\|ci\|lint\|git\|all>]` | Background monitoring loop — watch CI, tests, lint, and git state |
+| `/geno-dev-prs-check [repo\|--all]` | Check open PRs and flag ones that may need closing |
+| `/geno-dev-branches-audit [repo\|--all]` | Audit all branches — find ones needing PRs, ready to merge, or stale |
+| `/geno-dev-scheduling-snooze <time> [prompt]` | Snooze session until a specified time, then execute a prompt |
 
 ## Next steps
 

--- a/skills/geno-dev-loops-autopilot/SKILL.md
+++ b/skills/geno-dev-loops-autopilot/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: geno-dev-loops-autopilot
+description: >-
+  Background monitoring loop — periodically checks CI, tests, lint, and git
+  status, auto-fixing low-risk issues or alerting when human attention is
+  needed. Use when user says /geno-dev-loops-autopilot.
+argument-hint: "[task] [--watch <tests|ci|lint|git|all>] [--every <15m|30m>] [--for <duration>]"
+license: MIT
+metadata:
+  author: 42euge
+  version: "0.1.0"
+---
+
+# Autopilot Loop
+
+Background monitoring and maintenance loop. Watches the repo or PR over a long window and reacts when conditions change. Low intensity and reactive: it wakes on a cron, checks health signals, applies safe fixes when obvious, and escalates anything ambiguous.
+
+## Input
+
+Parse `$ARGUMENTS` for:
+
+- **Task pattern** — fuzzy-matches against geno-notes tasks (optional)
+- **`--watch <tests|ci|lint|git|all>`** — what to monitor. Default: `all`
+- **`--every <15m|30m>`** — wake interval. Default: `15m`
+- **`--for <duration>`** — total monitoring window. Default: `24h`, max `7d`
+
+If no explicit watch target is given, monitor `ci`, `lint`, `tests`, and `git`.
+
+## When to Use
+
+- You opened a PR and want passive CI/watchdog coverage
+- You want regression catching while other work is happening
+- You need low-touch maintenance over hours instead of an active tight loop
+- You want automatic journaling of failures, fixes, and follow-up tasks
+
+Do **not** use when the goal is active implementation (use Turbocharge or Cruise), exploratory research (use Drift), or a one-time delayed action (use Snooze).
+
+## Workflow
+
+### 1. Load context
+
+- Check for geno-notes project scope: `geno-notes list --project --status active --json`
+- If a task pattern was provided, activate it: `geno-notes start <pattern> --project`
+- Detect repo, current branch, default branch, and whether the branch has an open PR
+- Create session directory:
+  ```
+  .geno/loops/autopilot/<YYYYMMDD-HHMM>/
+  ├── session.md
+  └── checkpoints/
+  ```
+- Write `session.md` header:
+  ```markdown
+  # Autopilot Session — <YYYY-MM-DD HH:MM>
+  ## Config
+  - Task: <geno-notes task id or "none">
+  - Watch: <tests, ci, lint, git>
+  - Interval: <15m or 30m>
+  - Duration: <target end time>
+  - Branch: <current branch>
+
+  ## Log
+  ```
+
+### 2. Establish baseline
+
+Record the starting state for each selected signal:
+
+- **tests** — detect the project's normal test command and run it once if it is safe and well-defined
+- **lint** — detect the lint command (or formatter/lint autofix command if available)
+- **ci** — inspect current PR checks or recent workflow runs with `gh`
+- **git** — capture working tree status, ahead/behind state, and merge-conflict markers
+
+Log the baseline in `session.md`:
+
+```markdown
+### Baseline — <timestamp>
+- Tests: passing / failing / unavailable
+- Lint: clean / failing / unavailable
+- CI: green / red / pending / unavailable
+- Git: clean / dirty / diverged
+```
+
+If no reliable local test or lint command can be detected, keep monitoring CI and git state instead of guessing.
+
+### 3. Schedule recurring checks
+
+- Use `CronCreate` to schedule recurring wakeups every 15 or 30 minutes
+- Set the schedule end time to the requested duration, capped at 7 days
+- Pass a wake prompt that includes:
+  - session directory
+  - watch targets
+  - branch / PR context
+  - conservative fix rules
+- Record the cron id and end time in `session.md`
+
+### 4. On each cycle
+
+On each wakeup:
+
+1. Re-check each selected signal
+2. Compare against the previous cycle and the baseline
+3. Classify findings:
+   - **Healthy** — no action needed
+   - **Retryable** — likely transient failure (for example flaky CI or network failure)
+   - **Safe fix** — deterministic, low-risk fix is available
+   - **Human action** — needs design judgment or touches user work
+
+Allowed safe fixes:
+
+- Run documented formatter or lint autofix commands
+- Regenerate deterministic tracked artifacts when the repo already treats them as generated outputs
+- Retry a failing test or CI check once when the failure looks transient
+
+If a safe fix changes tracked files:
+
+- Verify immediately with the relevant check
+- Only auto-commit on a non-default branch
+- Use a narrow commit message like `autopilot: fix lint drift`
+
+If the branch is the default branch, never auto-commit. Log the fix opportunity and alert instead.
+
+### 5. Log and journal
+
+Append each cycle to `session.md`:
+
+```markdown
+### Cycle <n> — <timestamp>
+- Findings: <summary>
+- Action: <none | retried | fixed | escalated>
+- Result: <green | still failing | waiting on human>
+```
+
+Integrate with geno-notes when available:
+
+- New failures or regressions → `geno-notes note ... --kind bug`
+- Successful auto-fixes → `geno-notes note ... --kind milestone`
+- Issues needing a human later → create or suggest a follow-up task
+
+### 6. Continue or stop
+
+Keep monitoring while progress is passive and safe.
+
+Stop the loop when:
+
+- The requested duration expires
+- The PR is merged or closed
+- The branch is deleted or no longer relevant
+- The same problem fails repeated retries or safe fixes
+- Human input is required
+
+When stopping, write a final summary to `session.md` and report whether the session ended cleanly, with fixes applied, or blocked on a person.
+
+## Error Recovery
+
+- If a check command crashes, retry once. If it crashes again, mark that signal unavailable and continue with the others.
+- If the same safe fix fails twice, stop retrying it and escalate.
+- If `gh` is unavailable, continue monitoring local signals and log degraded mode.
+- If `geno-notes` fails, keep monitoring and write the journal information to `session.md` instead.
+- Never do destructive git operations inside Autopilot: no force pushes, hard resets, rebases, merges, or automatic conflict resolution.
+
+## What NOT to Do
+
+- **Don't monitor forever.** Respect the `CronCreate` 7-day cap.
+- **Don't auto-fix ambiguous failures.** If the cause is not obvious, alert a human.
+- **Don't commit to the default branch.** Background maintenance must stay off `main`/`master`.
+- **Don't overwrite user changes.** If the tree is dirty from unrelated edits, log it and stop.
+- **Don't turn Autopilot into Turbocharge.** If the loop becomes active implementation, switch to a tighter execution loop.
+
+## Runtime
+
+No venv or scripts — pure markdown workflow. Uses `CronCreate` for 15–30 minute recurring checks over long-running sessions.

--- a/skills/geno-dev/SKILL.md
+++ b/skills/geno-dev/SKILL.md
@@ -4,12 +4,12 @@ description: >-
   Developer and infrastructure utilities — task execution from lab notes,
   git commit history rewriting, worktree management, workspace creation,
   session forking, end-to-end feature shipping, issue-driven development,
-  agentic loops, and scheduled snoozing.
+  agentic loops, background monitoring, and scheduled snoozing.
   Use when user says /geno-dev-tasks-start, /geno-dev-commits-rewrite,
   /geno-dev-worktrees-manage, /geno-dev-workspaces-init, /geno-dev-sessions-fork,
   /geno-dev-feature-ship, /geno-dev-issue-work, /geno-dev-loops-turbocharge,
-  /geno-dev-loops-cruise, /geno-dev-prs-check, /geno-dev-branches-audit,
-  or /geno-dev-scheduling-snooze.
+  /geno-dev-loops-cruise, /geno-dev-loops-autopilot, /geno-dev-prs-check,
+  /geno-dev-branches-audit, or /geno-dev-scheduling-snooze.
 license: MIT
 metadata:
   author: 42euge
@@ -18,7 +18,7 @@ metadata:
 
 # geno-dev — Developer Utilities
 
-Dev and infrastructure skills for AI coding agents. Task execution, git history rewriting, worktree management, workspace creation, session forking, end-to-end feature shipping, issue-driven development, agentic loops, PR checking, branch auditing, and scheduled snoozing.
+Dev and infrastructure skills for AI coding agents. Task execution, git history rewriting, worktree management, workspace creation, session forking, end-to-end feature shipping, issue-driven development, agentic loops, background monitoring, PR checking, branch auditing, and scheduled snoozing.
 
 ## Commands
 
@@ -33,6 +33,7 @@ Dev and infrastructure skills for AI coding agents. Task execution, git history 
 | `/geno-dev-issue-work [number\|query\|URL]` | Pick a GitHub issue or JIRA ticket and work on it (normal or loop mode) |
 | `/geno-dev-loops-turbocharge [task] [--spec <file>]` | Spec-driven convergence loop — iterate until all acceptance criteria pass |
 | `/geno-dev-loops-cruise [task] [--plan <file>]` | Plan-driven sequential loop — execute a plan one step at a time |
+| `/geno-dev-loops-autopilot [task] [--watch <tests\|ci\|lint\|git\|all>]` | Background monitoring loop — watch CI, tests, lint, and git state |
 | `/geno-dev-prs-check [repo\|--all]` | Check open PRs and flag ones that may need closing |
 | `/geno-dev-branches-audit [repo\|--all]` | Audit all branches — find ones needing PRs, ready to merge, or stale |
 | `/geno-dev-scheduling-snooze <time> [prompt]` | Snooze session until a specified time, then execute a prompt |


### PR DESCRIPTION
## Summary
- add the `geno-dev-loops-autopilot` skill for long-running background monitoring via `CronCreate`
- document conservative auto-fix and escalation rules for CI, tests, lint, and git-state watching
- register the command across umbrella manifests and docs, and sync the docs landing pages

## Verification
- `git diff --check`
- `mkdocs build --strict -d /tmp/geno-dev-site-autopilot`

Closes #16