### PR TITLE
Add overdrive loop skill

### DIFF
--- a/GENO.md
+++ b/GENO.md
@@ -1,6 +1,6 @@
 # geno-dev — developer utilities skillset
 
-Developer and infrastructure skills for AI coding agents: task execution from lab notes, git commit history rewriting, worktree management, workspace creation, session forking, agentic loops, and scheduled snoozing.
+Developer and infrastructure skills for AI coding agents: task execution from lab notes, git commit history rewriting, worktree management, workspace creation, session forking, issue-driven development, agentic loops, long-horizon role rotation, and scheduled snoozing.
 
 ## Skills
 
@@ -14,6 +14,7 @@ Developer and infrastructure skills for AI coding agents: task execution from la
 | geno-dev-sessions-fork | sessions | /geno-dev-sessions-fork |
 | geno-dev-loops-turbocharge | loops | /geno-dev-loops-turbocharge |
 | geno-dev-loops-cruise | loops | /geno-dev-loops-cruise |
+| geno-dev-loops-overdrive | loops | /geno-dev-loops-overdrive |
 | geno-dev-prs-check | prs | /geno-dev-prs-check |
 | geno-dev-branches-audit | branches | /geno-dev-branches-audit |
 | geno-dev-scheduling-snooze | scheduling | /geno-dev-scheduling-snooze |
@@ -38,6 +39,7 @@ geno-dev/
 │   ├── geno-dev-worktrees-manage/
 │   ├── geno-dev-loops-turbocharge/
 │   ├── geno-dev-loops-cruise/
+│   ├── geno-dev-loops-overdrive/
 │   ├── geno-dev-prs-check/
 │   ├── geno-dev-branches-audit/
 │   ├── geno-dev-scheduling-snooze/
@@ -67,6 +69,7 @@ Pure markdown skillset — no Python package, no venv, no scripts. Each skill is
 - **sessions-fork**: Extracts full session context via geno-mon for continuation in a new session.
 - **loops-turbocharge**: Spec-driven convergence loop — iterates until all acceptance criteria pass.
 - **loops-cruise**: Plan-driven sequential loop — executes a plan one step at a time via agent subagents.
+- **loops-overdrive**: Long-horizon adaptive loop — rotates Planner, Implementer, and Reviewer roles with checkpoint handoffs.
 - **prs-check**: Checks open PRs, classifies by status (closeable/stale/blocked/draft/approved), renders a table with links.
 - **branches-audit**: Audits all branches across a workspace or repo, classifying by PR status and suggesting next actions.
 - **scheduling-snooze**: Delays session work until a specified time using natural language, with chained wakeups for long delays.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # geno-dev
 
-Developer and infrastructure skills for AI coding agents. Task execution from lab notes, git commit history rewriting, worktree management, workspace creation, session forking, agentic loops, and scheduled snoozing.
+Developer and infrastructure skills for AI coding agents. Task execution from lab notes, git commit history rewriting, worktree management, workspace creation, session forking, issue-driven development, agentic loops, long-horizon role rotation, and scheduled snoozing.
 
 ## Install
 
@@ -17,9 +17,13 @@ geno-tools install geno-dev
 | `/geno-dev-worktrees-manage [list\|create\|switch\|prune]` | Manage git worktrees — list, create, switch, and prune |
 | `/geno-dev-workspaces-init [config\|list\|<text>]` | Create development workspaces from issues, tickets, repos, or ideas |
 | `/geno-dev-sessions-fork [session]` | Fork an agent session — extract context to continue in a new session |
+| `/geno-dev-feature-ship [description\|issue URL]` | End-to-end: scope, issue, branch, implement, and PR |
+| `/geno-dev-issue-work [number\|query\|URL]` | Pick a GitHub issue or JIRA ticket and work on it (normal or loop mode) |
 | `/geno-dev-loops-turbocharge [task] [--spec <file>]` | Spec-driven convergence loop — iterate until all acceptance criteria pass |
 | `/geno-dev-loops-cruise [task] [--plan <file>]` | Plan-driven sequential loop — execute a plan one step at a time |
+| `/geno-dev-loops-overdrive [task] [--brief <file>]` | Long-horizon adaptive loop — Planner -> Implementer -> Reviewer rotation |
 | `/geno-dev-prs-check [repo\|--all]` | Check open PRs and flag ones that may need closing |
+| `/geno-dev-branches-audit [repo\|--all]` | Audit all branches — find ones needing PRs, ready to merge, or stale |
 | `/geno-dev-scheduling-snooze <time> [prompt]` | Snooze session until a specified time, then execute a prompt |
 
 ## Repository structure
@@ -48,7 +52,15 @@ geno-dev/
 │   │   └── SKILL.md
 │   ├── geno-dev-loops-cruise/
 │   │   └── SKILL.md
+│   ├── geno-dev-loops-overdrive/
+│   │   └── SKILL.md
 │   ├── geno-dev-prs-check/
+│   │   └── SKILL.md
+│   ├── geno-dev-branches-audit/
+│   │   └── SKILL.md
+│   ├── geno-dev-feature-ship/
+│   │   └── SKILL.md
+│   ├── geno-dev-issue-work/
 │   │   └── SKILL.md
 │   └── geno-dev-scheduling-snooze/
 │       └── SKILL.md

--- a/SKILL.md
+++ b/SKILL.md
@@ -3,9 +3,13 @@ name: geno-dev
 description: >-
   Developer and infrastructure utilities — task execution from lab notes,
   git commit history rewriting, worktree management, workspace creation,
-  and session forking.
+  session forking, issue-driven development, agentic loops, long-horizon
+  role rotation, PR checking, branch auditing, and scheduled snoozing.
   Use when user says /geno-dev-tasks-start, /geno-dev-commits-rewrite,
-  /geno-dev-worktrees-manage, /geno-dev-workspaces-init, or /geno-dev-sessions-fork.
+  /geno-dev-worktrees-manage, /geno-dev-workspaces-init, /geno-dev-sessions-fork,
+  /geno-dev-feature-ship, /geno-dev-issue-work, /geno-dev-loops-turbocharge,
+  /geno-dev-loops-cruise, /geno-dev-loops-overdrive, /geno-dev-prs-check,
+  /geno-dev-branches-audit, or /geno-dev-scheduling-snooze.
 license: MIT
 metadata:
   author: 42euge
@@ -14,7 +18,7 @@ metadata:
 
 # geno-dev — Developer Utilities
 
-Dev and infrastructure skills for AI coding agents. Task execution, git history rewriting, worktree management, workspace creation, and session forking.
+Dev and infrastructure skills for AI coding agents. Task execution, git history rewriting, worktree management, workspace creation, session forking, issue-driven development, agentic loops, long-horizon role rotation, PR checking, branch auditing, and scheduled snoozing.
 
 ## Commands
 
@@ -25,6 +29,14 @@ Dev and infrastructure skills for AI coding agents. Task execution, git history 
 | `/geno-dev-worktrees-manage [list\|create\|switch\|prune]` | Manage git worktrees — list, create, switch, and prune |
 | `/geno-dev-workspaces-init [config\|list\|<text>]` | Create development workspaces from issues, tickets, repos, or ideas |
 | `/geno-dev-sessions-fork [session]` | Fork an agent session — extract context to continue in a new session |
+| `/geno-dev-feature-ship [description\|issue URL]` | End-to-end: scope, issue, branch, implement, and PR |
+| `/geno-dev-issue-work [number\|query\|URL]` | Pick a GitHub issue or JIRA ticket and work on it (normal or loop mode) |
+| `/geno-dev-loops-turbocharge [task] [--spec <file>]` | Spec-driven convergence loop — iterate until all acceptance criteria pass |
+| `/geno-dev-loops-cruise [task] [--plan <file>]` | Plan-driven sequential loop — execute a plan one step at a time |
+| `/geno-dev-loops-overdrive [task] [--brief <file>]` | Long-horizon adaptive loop — Planner -> Implementer -> Reviewer rotation |
+| `/geno-dev-prs-check [repo\|--all]` | Check open PRs and flag ones that may need closing |
+| `/geno-dev-branches-audit [repo\|--all]` | Audit all branches — find ones needing PRs, ready to merge, or stale |
+| `/geno-dev-scheduling-snooze <time> [prompt]` | Snooze session until a specified time, then execute a prompt |
 
 ## Runtime
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -160,6 +160,70 @@ Workspace settings at `~/.geno/config.yaml` (auto-created on first use):
 
 ---
 
+## Ship Feature
+
+**`/geno-dev-feature-ship [description|issue URL]`**
+
+Take a feature idea from scoping through implementation to a pull request.
+
+### Input
+
+- A freeform feature description
+- An existing GitHub issue URL
+
+If no argument is provided, the skill asks what the user wants to build.
+
+### Workflow
+
+1. **Scope the feature** — clarify requirements with the user, or fetch the linked GitHub issue
+2. **Create the issue** — draft and create a GitHub issue when starting from a freeform idea
+3. **Create the branch** — branch from the default branch with a descriptive name
+4. **Implement** — explore, plan if needed, code, document, and verify
+5. **Open the PR** — create a pull request that links back to the issue
+6. **Wrap up** — summarize what shipped and note any follow-up scope
+
+!!! tip
+    Use this when the work starts as an idea. If the issue already exists and you want to execute it directly, use `/geno-dev-issue-work`.
+
+**See also:** [Issue to PR workflow](workflows.md#issue-to-pr)
+
+---
+
+## Work on Issue
+
+**`/geno-dev-issue-work [number|query|URL]`**
+
+Pick a GitHub issue or JIRA ticket and execute it with either interactive or autonomous flow.
+
+### Input
+
+- A GitHub issue number
+- A JIRA key like `PROJ-1234`
+- A GitHub or JIRA URL
+- A search query for finding the issue
+
+### Workflow
+
+1. **Detect source** — determine GitHub vs. JIRA from the argument
+2. **Select the issue** — fetch directly or search and let the user choose
+3. **Read context** — summarize the issue body, constraints, and comments
+4. **Choose execution mode** — normal interactive mode or autonomous loop mode
+5. **Choose workspace strategy** — worktree or in-place
+6. **Create the branch** — branch from the default branch using the issue number or ticket key
+7. **Implement and ship** — do the work, verify it, and open the PR
+
+### Modes
+
+- **Normal mode** — interactive back-and-forth, best for ambiguous work
+- **Loop mode** — autonomous execution with periodic check-ins, best for well-defined work
+
+!!! tip
+    Prefer a separate worktree when your current checkout is dirty or you want parallel issue work without disturbing the main clone.
+
+**See also:** [Issue to PR workflow](workflows.md#issue-to-pr) · [Manage Worktrees](#manage-worktrees)
+
+---
+
 ## Turbocharge Loop
 
 **`/geno-dev-loops-turbocharge [task] [--spec <file>] [--max <n>]`**
@@ -221,6 +285,48 @@ If no plan is provided, checks `geno-notes plans/` for the task's plan, then ask
 
 !!! tip
     Pairs well with plan mode: use `/geno-dev-tasks-start` to plan a complex task, then run `/geno-dev-loops-cruise --plan geno/geno-notes/plans/<task>.md` to execute it.
+
+---
+
+## Overdrive Loop
+
+**`/geno-dev-loops-overdrive [task] [--brief <file>] [--for <duration>] [--max <n>]`**
+
+Long-horizon adaptive execution. Rotates through Planner, Implementer, and Reviewer roles in fresh agents, using checkpoint handoffs to sustain multi-hour work without silent context drift.
+
+### Input
+
+- A task pattern to fuzzy-match against geno-notes tasks (optional)
+- `--brief <file>` — seed the loop from an issue brief, plan, spec, or notes file
+- `--for <duration>` — target run length; defaults to `4h` and typically ranges from `2h` to `12h`
+- `--max <n>` — maximum cycles; overrides the duration-derived default
+
+### Workflow
+
+1. **Load context** — activate the task, summarize or copy the brief, detect repo state, and create `.geno/loops/overdrive/<timestamp>/`
+2. **Capture baseline** — record current constraints, branch state, and verification targets
+3. **Planner cycle** — choose the next bounded sprint slice and define what success looks like
+4. **Implementer cycle** — make focused progress on that slice and log milestones
+5. **Reviewer cycle** — verify the actual changes, record findings, and decide whether to continue, stop, or re-plan
+6. **Repeat rotation** — continue Planner -> Implementer -> Reviewer until complete, blocked, or at max cycles
+
+### Role rotation
+
+- **Planner** — reads the active task and previous checkpoint, then picks the next 1-3 concrete slices
+- **Implementer** — executes the highest-priority slice and records what changed
+- **Reviewer** — validates the work, looks for regressions or scope drift, and drives the next handoff
+
+### Duration mapping
+
+| Duration | Default cycles |
+|---|---|
+| `2h` | 4 |
+| `4h` | 8 |
+| `8h` | 16 |
+| `12h` | 24 |
+
+!!! tip
+    Use Overdrive when the work is too long or dynamic for Cruise, but still goal-oriented enough that each cycle should end with a concrete decision or verification result.
 
 ---
 

--- a/skills/geno-dev-loops-overdrive/SKILL.md
+++ b/skills/geno-dev-loops-overdrive/SKILL.md
@@ -1,0 +1,288 @@
+---
+name: geno-dev-loops-overdrive
+description: >-
+  Long-horizon adaptive execution loop with Planner -> Implementer ->
+  Reviewer rotation and checkpoint handoffs. Use when user says
+  /geno-dev-loops-overdrive.
+argument-hint: "[task] [--brief <file>] [--for <duration>] [--max <n>]"
+license: MIT
+metadata:
+  author: 42euge
+  version: "0.1.0"
+---
+
+# Overdrive Loop
+
+Long-horizon adaptive execution loop. It rotates through three roles — Planner, Implementer, and Reviewer — with a fresh Agent each cycle and a checkpoint handoff between them. Overdrive is the generalized version of Supercharge: built for sustained autonomous work in normal repos, not tied to Kaggle or benchmark harnesses.
+
+## Input
+
+Parse `$ARGUMENTS` for:
+
+- **Task pattern** — fuzzy-matches against geno-notes tasks (optional)
+- **`--brief <file>`** — optional issue brief, plan, spec, or notes file to seed the loop
+- **`--for <duration>`** — target run length (default: `4h`, typical range: `2h` to `12h`)
+- **`--max <n>`** — maximum cycles; overrides duration-derived default
+
+If neither a task pattern nor a brief is provided, use `AskUserQuestion` to ask the user for one of:
+1. A high-level goal
+2. A brief file path
+3. "Start from current issue/task"
+
+## Duration Dial
+
+Each cycle should target roughly 20-30 minutes of focused work before handing off:
+
+| Duration | Default cycles | Typical use |
+|---|---|---|
+| `2h` | 4 | Focused push on one feature slice |
+| `4h` | 8 | Medium feature or refactor |
+| `8h` | 16 | Large feature across multiple subsystems |
+| `12h` | 24 | Maximum deep autonomous run |
+
+If `--max` is provided, it takes precedence over the duration mapping.
+
+## When to Use
+
+- Large features, migrations, or sustained implementation work that will evolve as you learn
+- Work that needs periodic re-planning, not just blind execution
+- Branches where you want explicit verification and critique between implementation bursts
+- Issue-driven or task-driven work where the agent should keep moving for hours without drifting
+
+Do **not** use when the work already has a fixed ordered plan (use Cruise), when it has a tight pass/fail spec (use Turbocharge), or when the main job is passive monitoring rather than active implementation.
+
+## Storage
+
+Create a session directory:
+
+```
+.geno/loops/overdrive/<YYYYMMDD-HHMM>/
+├── session.md
+├── brief.md
+├── checkpoints/
+│   ├── cycle_01_planner.md
+│   ├── cycle_02_implementer.md
+│   ├── cycle_03_reviewer.md
+│   └── ...
+└── artifacts/
+```
+
+Use it as the durable handoff surface across fresh-agent cycles.
+
+## Workflow
+
+### 1. Load context
+
+- Check for geno-notes project scope: `geno-notes list --project --status active --json`
+- If a task pattern was provided, activate it: `geno-notes start <pattern> --project`
+- If no active task matches and the user gave a goal, create one: `geno-notes add "<goal>" --project`
+- Read the brief file if one was provided; otherwise summarize the issue, task, or user goal into `brief.md`
+- Detect repo, current branch, default branch, working tree status, and any existing open PR
+- Write `session.md` header:
+  ```markdown
+  # Overdrive Session — <YYYY-MM-DD HH:MM>
+  ## Config
+  - Task: <geno-notes task id or "none">
+  - Brief: <brief file path or generated>
+  - Duration: <requested duration>
+  - Max cycles: <n>
+  - Branch: <current branch>
+
+  ## Log
+  ```
+
+### 2. Establish baseline
+
+Capture the starting state before the first role runs:
+
+- Active geno-notes tasks and any task already in progress
+- Repo status and ahead/behind state
+- Key constraints from the brief
+- Known verification targets (tests, docs, commands, manual checks)
+
+Append a baseline note to `session.md` so later reviews can compare progress against a real starting point.
+
+### 3. Pick the next role
+
+Role rotation is strict unless a blocker forces escalation:
+
+1. **Planner**
+2. **Implementer**
+3. **Reviewer**
+4. Repeat from Planner
+
+Rules:
+
+- If there is no prior checkpoint, start with Planner
+- If the last Reviewer checkpoint says "complete", stop
+- If the last checkpoint says "blocked on user decision", stop and ask the user
+- If the last Reviewer checkpoint found regressions or scope drift, the next cycle must be Planner, not another Implementer pass
+
+### 4. Planner cycle
+
+Spawn a fresh **Planner** agent with:
+
+- `brief.md`
+- `session.md`
+- The latest checkpoint (if any)
+- Current repo status and active task list
+
+Planner responsibilities:
+
+- Re-read the task and decide the next 1-3 concrete slices
+- Prioritize based on impact, risk, and what was learned in the previous review
+- Define explicit verification targets for the next implementation cycle
+- Keep scope bounded: the plan should fit one implementer burst, not the whole project
+
+Planner writes `checkpoints/cycle_<n>_planner.md`:
+
+```markdown
+# Overdrive Planner Checkpoint — Cycle <n>
+## Objective
+<what this sprint is trying to achieve>
+## Priority slices
+1. <slice>
+2. <slice>
+## Files / areas
+<likely files or subsystems>
+## Verification target
+<tests, commands, docs, manual checks>
+## Risks / assumptions
+<what could go wrong>
+## Handoff to Implementer
+<what to do next>
+```
+
+### 5. Implementer cycle
+
+Spawn a fresh **Implementer** agent with:
+
+- `brief.md`
+- The latest Planner checkpoint
+- Relevant local files
+
+Implementer responsibilities:
+
+- Execute the highest-priority slice from the plan
+- Make bounded, coherent changes rather than sprawling edits
+- Run the lightest useful self-checks before handing off
+- Log a milestone to geno-notes when meaningful progress is made:
+  ```bash
+  geno-notes note "Overdrive implementer cycle <n>: <summary>" --task <id> --kind milestone --project
+  ```
+
+Implementer writes `checkpoints/cycle_<n>_implementer.md`:
+
+```markdown
+# Overdrive Implementer Checkpoint — Cycle <n>
+## What changed
+<summary>
+## Files modified
+<list>
+## Checks run
+<commands and outcomes>
+## Remaining gaps
+<what is still incomplete>
+## Handoff to Reviewer
+<what needs verification>
+```
+
+### 6. Reviewer cycle
+
+Spawn a fresh **Reviewer** agent with:
+
+- `brief.md`
+- The latest Implementer checkpoint
+- Access to the modified files and diff
+
+Reviewer responsibilities:
+
+- Verify the implementer's claims against the actual repo state
+- Run targeted checks, spot-check docs, and look for regressions or scope drift
+- Decide whether the work is:
+  - **ready to continue** with a new plan
+  - **complete** for the goal
+  - **blocked** on a user decision
+  - **failing** and needs course correction
+- Log findings to geno-notes:
+  ```bash
+  geno-notes note "Overdrive review cycle <n>: <finding>" --task <id> --kind note --project
+  ```
+  Use `--kind bug` instead when the review surfaces a concrete regression.
+
+Reviewer writes `checkpoints/cycle_<n>_reviewer.md`:
+
+```markdown
+# Overdrive Reviewer Checkpoint — Cycle <n>
+## Verdict
+<continue | complete | blocked | replan>
+## Evidence
+<tests, inspection, docs checks>
+## Findings
+<bugs, risks, design notes, scope issues>
+## Recommended next action
+<planner should do X next>
+## Handoff to Planner
+<what the next cycle must consider>
+```
+
+### 7. Log the cycle
+
+After each role cycle:
+
+- Append a short entry to `session.md`
+  ```markdown
+  ### Cycle <n> — <Planner|Implementer|Reviewer> — <timestamp>
+  <summary>
+  ```
+- Save or reconstruct the checkpoint if the agent forgot to write it
+- Keep the checkpoint concise but sufficient for a fresh agent to continue without hidden context
+
+### 8. Loop or complete
+
+**If work remains and cycles < max:**
+1. Choose the next role from the rotation
+2. Use `ScheduleWakeup` to continue the loop inside `/loop`
+3. Prefer short delays (60-180s) during active local work and longer delays only when waiting on external validation
+
+**If the Reviewer says complete:**
+1. Write final summary to `session.md`
+2. Log completion:
+   ```bash
+   geno-notes note "Overdrive complete: <summary>" --task <id> --kind milestone --project
+   ```
+3. If the task is fully done: `geno-notes done <id> --project`
+4. Stop the loop and report the result
+
+**If blocked on user input:**
+1. Write a partial summary to `session.md`
+2. Present the blocker clearly to the user
+3. Stop until the user responds
+
+## Context Management
+
+- Every cycle uses a **fresh Agent** to avoid context drift
+- The checkpoint is the contract between roles
+- `session.md` is append-only history, not the main handoff artifact
+- Planner should never rely on memory that was not written down
+
+## Error Recovery
+
+- If Planner produces a vague or oversized sprint, rerun planning once with a tighter scope. If it is still vague, ask the user.
+- If Implementer makes no meaningful progress for two implementation cycles on the same slice, force a Planner replan.
+- If Reviewer finds a regression, do not continue straight into another implementation burst without a fresh Planner checkpoint.
+- If a checkpoint file is missing, reconstruct it from the agent output and `git diff`.
+- If `geno-notes` fails, continue the loop and write the missing journal information to `session.md`.
+- Never do destructive git operations inside Overdrive: no force pushes, hard resets, rebases, or branch deletions.
+
+## What NOT to Do
+
+- **Don't let Planner write a full-project master plan every cycle.** Plan only the next bounded slice.
+- **Don't let Implementer wander outside the planned verification target.** Broad rewrites break the loop.
+- **Don't let Reviewer rubber-stamp work.** A review must include evidence or an explicit reason evidence was unavailable.
+- **Don't skip the checkpoint.** Hidden context is how multi-hour loops degrade.
+- **Don't keep looping once the work is clearly blocked on human judgment.** Stop and escalate.
+
+## Runtime
+
+No venv or scripts — pure markdown workflow. Uses Agent subagents for role rotation and `ScheduleWakeup` for self-pacing within `/loop`.

--- a/skills/geno-dev/SKILL.md
+++ b/skills/geno-dev/SKILL.md
@@ -4,11 +4,11 @@ description: >-
   Developer and infrastructure utilities — task execution from lab notes,
   git commit history rewriting, worktree management, workspace creation,
   session forking, end-to-end feature shipping, issue-driven development,
-  agentic loops, and scheduled snoozing.
+  agentic loops, long-horizon role rotation, and scheduled snoozing.
   Use when user says /geno-dev-tasks-start, /geno-dev-commits-rewrite,
   /geno-dev-worktrees-manage, /geno-dev-workspaces-init, /geno-dev-sessions-fork,
   /geno-dev-feature-ship, /geno-dev-issue-work, /geno-dev-loops-turbocharge,
-  /geno-dev-loops-cruise, /geno-dev-prs-check, /geno-dev-branches-audit,
+  /geno-dev-loops-cruise, /geno-dev-loops-overdrive, /geno-dev-prs-check, /geno-dev-branches-audit,
   or /geno-dev-scheduling-snooze.
 license: MIT
 metadata:
@@ -18,7 +18,7 @@ metadata:
 
 # geno-dev — Developer Utilities
 
-Dev and infrastructure skills for AI coding agents. Task execution, git history rewriting, worktree management, workspace creation, session forking, end-to-end feature shipping, issue-driven development, agentic loops, PR checking, branch auditing, and scheduled snoozing.
+Dev and infrastructure skills for AI coding agents. Task execution, git history rewriting, worktree management, workspace creation, session forking, end-to-end feature shipping, issue-driven development, agentic loops, long-horizon role rotation, PR checking, branch auditing, and scheduled snoozing.
 
 ## Commands
 
@@ -33,6 +33,7 @@ Dev and infrastructure skills for AI coding agents. Task execution, git history 
 | `/geno-dev-issue-work [number\|query\|URL]` | Pick a GitHub issue or JIRA ticket and work on it (normal or loop mode) |
 | `/geno-dev-loops-turbocharge [task] [--spec <file>]` | Spec-driven convergence loop — iterate until all acceptance criteria pass |
 | `/geno-dev-loops-cruise [task] [--plan <file>]` | Plan-driven sequential loop — execute a plan one step at a time |
+| `/geno-dev-loops-overdrive [task] [--brief <file>]` | Long-horizon adaptive loop — Planner -> Implementer -> Reviewer rotation |
 | `/geno-dev-prs-check [repo\|--all]` | Check open PRs and flag ones that may need closing |
 | `/geno-dev-branches-audit [repo\|--all]` | Audit all branches — find ones needing PRs, ready to merge, or stale |
 | `/geno-dev-scheduling-snooze <time> [prompt]` | Snooze session until a specified time, then execute a prompt |


### PR DESCRIPTION
## Summary
- add `geno-dev-loops-overdrive` as a long-horizon Planner -> Implementer -> Reviewer loop
- register the new loop in umbrella skill manifests and repo docs
- sync README and command docs with the existing feature-ship / issue-work / branches-audit commands while adding overdrive

## Notes
- `CLAUDE.md` in this repo is a direct passthrough to `GENO.md`, so updating `GENO.md` is the effective CLAUDE-facing change.

Closes #11