### PR TITLE
Add observability and trace emission to skills, enhance retro

### DIFF
--- a/skills/geno-dev-feature-ship/SKILL.md
+++ b/skills/geno-dev-feature-ship/SKILL.md
@@ -8,6 +8,16 @@ license: MIT
 metadata:
   author: 42euge
   version: "0.1.0"
+observability:
+  success_signal: "PR created and URL presented to user"
+  failure_signals:
+    - "no GitHub remote available"
+    - "implementation blocked"
+  knowledge_reads:
+    - "GitHub issues (via gh CLI)"
+  knowledge_writes:
+    - "GitHub issue (created)"
+    - "GitHub PR (created)"
 ---
 
 # Ship Feature
@@ -74,3 +84,20 @@ Present the PR URL to the user.
 ### 6. Wrap up
 
 Summarize what was shipped: the issue, branch, PR, and key implementation decisions. If there are follow-up items (future scope from step 1), mention them so nothing is lost.
+
+## Completion
+
+When this skill finishes, emit a trace:
+
+```bash
+geno-trace emit \
+  --skill geno-dev-feature-ship \
+  --status <success|failure|abandoned> \
+  --tool-calls <approximate count> \
+  --errors <count of tool/command errors> \
+  --produced "github-issue github-pr"
+```
+
+- `success` = PR created
+- `failure` = could not complete implementation
+- `abandoned` = user stopped before PR

--- a/skills/geno-dev-issue-work/SKILL.md
+++ b/skills/geno-dev-issue-work/SKILL.md
@@ -9,6 +9,15 @@ license: MIT
 metadata:
   author: 42euge
   version: "0.1.0"
+observability:
+  success_signal: "PR created linking the issue"
+  failure_signals:
+    - "step failed twice in loop mode"
+    - "no GitHub remote or JIRA access"
+  knowledge_reads:
+    - "GitHub issues or JIRA tickets"
+  knowledge_writes:
+    - "GitHub PR (created)"
 ---
 
 # Work on Issue
@@ -133,3 +142,20 @@ Work autonomously using `ScheduleWakeup` to self-pace:
 - Stop the loop and present the PR URL to the user
 
 Use `ScheduleWakeup` with the `/loop` prompt to continue each iteration. Choose delay based on the work: 60–90s for active implementation, 120–270s if waiting on a build or test run.
+
+## Completion
+
+When this skill finishes (in either normal or loop mode), emit a trace:
+
+```bash
+geno-trace emit \
+  --skill geno-dev-issue-work \
+  --status <success|failure|abandoned> \
+  --tool-calls <approximate count> \
+  --errors <count of tool/command errors> \
+  --produced "github-pr"
+```
+
+- `success` = PR created linking the issue
+- `failure` = could not complete (blocked, no access)
+- `abandoned` = user stopped before PR

--- a/skills/geno-dev-loops-cruise/SKILL.md
+++ b/skills/geno-dev-loops-cruise/SKILL.md
@@ -8,6 +8,17 @@ license: MIT
 metadata:
   author: 42euge
   version: "0.1.0"
+observability:
+  success_signal: "all plan steps completed successfully"
+  failure_signals:
+    - "step failed twice consecutively"
+    - "user intervention required"
+  knowledge_reads:
+    - "geno-notes tasks (active, project scope)"
+    - "geno-notes plans"
+  knowledge_writes:
+    - "geno-notes journal (milestones per step)"
+    - ".geno/loops/cruise/*/session.md"
 ---
 
 # Cruise Loop
@@ -186,6 +197,25 @@ If verification fails:
 - **Don't parallelize steps.** Steps are sequential by design. If you notice independent steps, suggest NOS for next time.
 - **Don't modify the plan file.** The plan is the contract. Deviations go in `session.md` and geno-notes, not the plan itself.
 - **Don't continue after two failures on the same step.** Escalate to the user.
+
+## Completion
+
+When this skill finishes (success, failure, or abandoned), emit a trace:
+
+```bash
+geno-trace emit \
+  --skill geno-dev-loops-cruise \
+  --status <success|failure|abandoned> \
+  --tool-calls <approximate count> \
+  --errors <count of tool/command errors> \
+  --task <geno-notes task id, if any> \
+  --scope project \
+  --produced ".geno/loops/cruise/<session>/session.md"
+```
+
+- `success` = all plan steps completed
+- `failure` = step failed twice or user had to intervene on a blocker
+- `abandoned` = user stopped the loop early
 
 ## Runtime
 

--- a/skills/geno-dev-loops-turbocharge/SKILL.md
+++ b/skills/geno-dev-loops-turbocharge/SKILL.md
@@ -8,6 +8,18 @@ license: MIT
 metadata:
   author: 42euge
   version: "0.1.0"
+observability:
+  success_signal: "all acceptance criteria pass"
+  failure_signals:
+    - "max iterations reached with failing criteria"
+    - "spec runner crashed twice"
+    - "same criterion fails 3 iterations in a row"
+  knowledge_reads:
+    - "geno-notes tasks (active, project scope)"
+    - "geno-notes plans"
+  knowledge_writes:
+    - "geno-notes journal (milestones per criterion)"
+    - ".geno/loops/turbocharge/*/session.md"
 ---
 
 # Turbocharge Loop
@@ -153,6 +165,25 @@ geno-notes note "Turbocharge: <criterion> now passing" --task <id> --kind milest
 - **Don't make unrelated changes.** If you notice other issues, log them as `geno-notes note --kind bug` but don't fix them in this loop.
 - **Don't continue past max iterations.** Respect the limit — infinite loops waste resources.
 - **Don't run without a spec.** If there's nothing to validate against, suggest Boost or Drift instead.
+
+## Completion
+
+When this skill finishes (success, failure, or abandoned), emit a trace:
+
+```bash
+geno-trace emit \
+  --skill geno-dev-loops-turbocharge \
+  --status <success|failure|abandoned> \
+  --tool-calls <approximate count> \
+  --errors <count of tool/command errors> \
+  --task <geno-notes task id, if any> \
+  --scope project \
+  --produced ".geno/loops/turbocharge/<session>/session.md"
+```
+
+- `success` = all criteria pass
+- `failure` = max iterations reached or spec runner broken
+- `abandoned` = user stopped the loop early
 
 ## Runtime
 

--- a/skills/geno-dev-skills-retro/SKILL.md
+++ b/skills/geno-dev-skills-retro/SKILL.md
@@ -4,11 +4,26 @@ description: >-
   Meta-harness — analyze a failed session, identify root causes, and patch the
   responsible skill to prevent the same failure. Self-improving skill loop.
   Use when user says /geno-dev-skills-retro.
-argument-hint: "[session] [--skill <name>] [--dry-run]"
+argument-hint: "[session] [--skill <name>] [--dry-run] [--batch]"
 license: MIT
 metadata:
   author: 42euge
-  version: "0.1.0"
+  version: "0.2.0"
+observability:
+  success_signal: "patches applied and accepted by user"
+  failure_signals:
+    - "no actionable signals found in session"
+    - "user rejected all patches"
+    - "transcript not found or unreadable"
+  knowledge_reads:
+    - "~/.geno/traces/ (structured skill traces)"
+    - "~/.geno/health/ (skill health cards)"
+    - "~/.geno/retro/queue.jsonl (batch queue)"
+    - "~/.claude/projects/ (session transcripts)"
+  knowledge_writes:
+    - ".geno/retro/<session-id>/ (analysis artifacts)"
+    - "geno-notes journal (milestones)"
+    - "skill SKILL.md files (patches)"
 ---
 
 # Skills Retro
@@ -22,8 +37,9 @@ Parse `$ARGUMENTS` for:
 - **Session** — session ID (partial match OK), PID number, or JSONL path (optional — defaults to most recent session in this project)
 - **`--skill <name>`** — skip auto-detection and target a specific skill for patching
 - **`--dry-run`** — analyze and propose changes but don't write them
+- **`--batch`** — process the retro queue at `~/.geno/retro/queue.jsonl` instead of a single session. Each line contains a trace ID referencing a failed skill run. Process all queued items, deduplicate findings, and present a unified patch set.
 
-If no session is given, list the 5 most recent sessions for this project and ask the user to pick one.
+If no session is given and `--batch` is not set, list the 5 most recent sessions for this project and ask the user to pick one.
 
 ## When to Use
 
@@ -59,6 +75,25 @@ for f in glob.glob(os.path.expanduser('~/.claude/sessions/*.json')):
 ```
 
 If the user gave a partial ID or PID, match it. If ambiguous, show candidates and ask.
+
+### 1.5. Check for structured traces (preferred)
+
+Before parsing raw transcripts, check if structured traces exist for this session:
+
+```bash
+geno-trace list --json --limit 100
+```
+
+Filter traces matching the session. If traces are found:
+
+- Each trace gives you the skill name, outcome status, error type, tool call count, and thrashing score directly — no need to infer these from raw JSONL.
+- Use `geno-trace health --skill <name>` for each involved skill to see aggregate patterns (success rate, recurring error types, whether the skill already `needs_retro`).
+- For `--batch` mode: read `~/.geno/retro/queue.jsonl`, look up each trace ID via `geno-trace list`, and group findings by skill.
+- Traces with `outcome.status == "failure"` or `outcome.status == "partial"` are the primary retro targets.
+
+If traces exist and provide enough signal (skill name + error type are known), you can skip the raw transcript parsing (step 2) and jump directly to step 4 (trace to skill) with the trace metadata. Fall back to full transcript parsing only when:
+- No traces exist for this session (pre-trace-era sessions)
+- The trace lacks sufficient detail (`error_type` is null and you need to understand *why* it failed)
 
 ### 2. Parse the transcript
 
@@ -239,6 +274,29 @@ Use `AskUserQuestion` to confirm each change:
 
 For accepted changes, use the `Edit` tool to modify the skill's SKILL.md. Edit the **repo copy** (under `./skills/<name>/SKILL.md`) — the installed copy at `~/.agents/skills/` is a symlink or will be synced by `geno-tools update`.
 
+#### Mode-aware delivery
+
+After applying patches, create a local branch for the changes:
+
+```bash
+cd <skill-repo-root>
+git checkout -b retro/<skill-name>-$(date +%Y%m%d)
+git add skills/<skill-name>/SKILL.md
+git commit -m "retro: patch <skill-name> — <root-cause-category>"
+```
+
+**Dev mode** (check `$GENO_MODE` env var or if cwd is in a geno-* workspace):
+- Push the branch and create a PR with `gh pr create`
+- Scrub the PR body: strip absolute paths (`/Users/...` → `./...`), raw code snippets from user projects, and error messages that might contain secrets
+- PR body should describe *what* was patched and *why* (root cause category), not reproduce raw session content
+
+**User mode** (default):
+- Keep the branch local — do not push
+- Write a notification to `~/.geno/iso/inbox.jsonl`:
+  ```bash
+  echo '{"type":"retro","skill":"<name>","branch":"retro/<name>-<date>","summary":"<one-line>","timestamp":"<ISO>"}' >> ~/.geno/iso/inbox.jsonl
+  ```
+
 After applying:
 
 ```bash
@@ -309,6 +367,40 @@ Only save memories for patterns that transcend the specific skill being patched.
 - **Don't modify the transcript.** Transcripts are immutable records. Analysis goes in `.geno/retro/`, not the JSONL.
 - **Don't apply patches without user confirmation** (unless `--auto` is explicitly passed — not in v0.1).
 - **Don't patch external tools.** If the failure is in `geno-notes`, `git`, or a test runner, note it but don't try to fix their code.
+
+## Batch Mode
+
+When `--batch` is passed:
+
+1. Read `~/.geno/retro/queue.jsonl`. Each line is a JSON object with at minimum `{"trace_id": "..."}`.
+2. For each trace ID, look up the trace via `geno-trace list --json` and match by ID.
+3. Group traces by skill name. For each skill:
+   - Read the skill's health card: `geno-trace health --skill <name>`
+   - Collect all failure traces (status = failure or partial)
+   - Cross-reference with the raw transcript only if the trace lacks `error_type`
+4. Deduplicate findings — if the same root cause appears across multiple traces, present it once with a frequency annotation ("seen in N traces").
+5. Present a unified patch set per skill, prioritized by:
+   - Skills with `needs_retro: true` in their health card (success rate < 70%)
+   - Skills with the most failure traces
+   - Skills with declining success rates (recent failures outweigh older successes)
+6. After processing, truncate `~/.geno/retro/queue.jsonl` to remove processed entries.
+
+## Completion
+
+When this skill finishes, emit a trace:
+
+```bash
+geno-trace emit \
+  --skill geno-dev-skills-retro \
+  --status <success|failure|abandoned> \
+  --tool-calls <approximate count> \
+  --errors <count of tool/command errors> \
+  --produced ".geno/retro/<session-id>/retro.md"
+```
+
+- `success` = patches applied and accepted
+- `failure` = no actionable signals found, or analysis failed
+- `abandoned` = user rejected all patches or stopped early
 
 ## Runtime
 

--- a/skills/geno-dev-tasks-start/SKILL.md
+++ b/skills/geno-dev-tasks-start/SKILL.md
@@ -8,6 +8,18 @@ license: MIT
 metadata:
   author: 42euge
   version: "0.1.0"
+observability:
+  success_signal: "task marked done in geno-notes"
+  failure_signals:
+    - "user had to abandon task"
+    - "no geno-notes scope found"
+  knowledge_reads:
+    - "geno-notes tasks"
+    - "geno-notes journal"
+    - "geno-notes plans"
+  knowledge_writes:
+    - "geno-notes journal (milestones)"
+    - "geno-notes plans (if medium/large task)"
 ---
 
 # Start Task
@@ -79,3 +91,21 @@ When the task is finished:
 2. Add a final note to `notes.md` summarizing what was done
 3. If a plan file was created, leave it as-is for reference
 4. Tell the user what was accomplished and suggest what to work on next from the remaining tasks
+
+## Completion
+
+When this skill finishes (success, failure, or abandoned), emit a trace:
+
+```bash
+geno-trace emit \
+  --skill geno-dev-tasks-start \
+  --status <success|failure|abandoned> \
+  --tool-calls <approximate count> \
+  --errors <count of tool/command errors> \
+  --task <geno-notes task id, if any> \
+  --scope <project|global>
+```
+
+- `success` = task marked done
+- `failure` = task could not be completed (blocker, missing context)
+- `abandoned` = user chose to stop or switch tasks


### PR DESCRIPTION
## Summary

Phase 1+2 of the three-pillars initiative. Adds observability frontmatter and trace emission (`geno-trace emit`) to 5 pilot skills, and enhances the retro skill for structured trace analysis.

**Pilot skills updated:**
- `geno-dev-loops-turbocharge` — observability frontmatter + completion trace
- `geno-dev-loops-cruise` — observability frontmatter + completion trace
- `geno-dev-tasks-start` — observability frontmatter + completion trace
- `geno-dev-feature-ship` — observability frontmatter + completion trace
- `geno-dev-issue-work` — observability frontmatter + completion trace

**Retro skill enhancements:**
- Step 1.5: read structured traces via `geno-trace list` before raw JSONL parsing
- `--batch` flag for processing `~/.geno/retro/queue.jsonl`
- Mode-aware patch delivery (dev mode → scrubbed auto-PRs, user mode → local branches + inbox)
- Frequency-annotated dedup in batch mode
- Completion trace emission

**Depends on:** 42euge/geno-tools#45 (geno-trace CLI)

## Test plan

- [ ] Invoke turbocharge — verify it emits trace on completion
- [ ] `geno-trace emit --skill test --status failure` → queues to retro queue
- [ ] `/geno-dev-skills-retro --batch` processes queued traces
- [ ] Retro reads health cards to prioritize skills
- [ ] In user mode, retro creates local branch without pushing