### PR TITLE
Add Three Pillars skill observability

### DIFF
--- a/skills/geno-dev-branches-audit/SKILL.md
+++ b/skills/geno-dev-branches-audit/SKILL.md
@@ -218,3 +218,19 @@ Ready to merge: PR #52 (docs/improve-site) — approved, no conflicts
 - Do NOT include the default branch (main/master) or `gh-pages` in the audit.
 - Do NOT show Claude Code worktrees (paths containing `/.claude/worktrees/`) — these are managed by Claude Code's isolation system.
 - Do NOT prompt the user for input during the audit. Run to completion and present results.
+
+## Completion
+
+When this skill finishes, emit a trace:
+
+```bash
+geno-trace emit \
+  --skill geno-dev-branches-audit \
+  --status <success|failure|abandoned> \
+  --tool-calls <approximate count> \
+  --errors <count of tool/command errors>
+```
+
+- `success` = audit table rendered with status tags and suggested actions for all resolved repos
+- `failure` = no repos resolved, or git/gh commands failed before producing a usable table
+- `abandoned` = user stopped early

--- a/skills/geno-dev-commits-rewrite/SKILL.md
+++ b/skills/geno-dev-commits-rewrite/SKILL.md
@@ -87,3 +87,19 @@ Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
 
 - Ask user if they want to delete the backup branch
 - If yes, delete it: `git branch -d backup-before-rewrite`
+
+## Completion
+
+When this skill finishes, emit a trace:
+
+```bash
+geno-trace emit \
+  --skill geno-dev-commits-rewrite \
+  --status <success|failure|abandoned> \
+  --tool-calls <approximate count> \
+  --errors <count of tool/command errors>
+```
+
+- `success` = commit history rewritten and verified (diff against backup is empty, no content lost)
+- `failure` = rewrite failed mid-way, repo left in inconsistent state, or content was lost
+- `abandoned` = user rejected the proposed commit plan or stopped early

--- a/skills/geno-dev-feature-ship/SKILL.md
+++ b/skills/geno-dev-feature-ship/SKILL.md
@@ -30,6 +30,10 @@ Take a feature idea from discussion through to a pull request: scope the work wi
 
 ## Workflow
 
+### 0. Load knowledge context
+
+Run `geno-notes context --skill geno-dev-feature-ship [--task <id>]` and review the returned bundle (active tasks, recent journal, relevant wiki, skill health). Use these to inform your approach — prior failures, relevant patterns, and active tasks provide context the user may not have stated explicitly.
+
 ### 1. Scope the feature
 
 If `$ARGUMENTS` is a GitHub issue URL, fetch it with `gh issue view` and skip to step 2.

--- a/skills/geno-dev-issue-work/SKILL.md
+++ b/skills/geno-dev-issue-work/SKILL.md
@@ -36,6 +36,10 @@ Pick a GitHub issue or JIRA ticket and start working on it. Offers two execution
 
 ## Workflow
 
+### 0. Load knowledge context
+
+Run `geno-notes context --skill geno-dev-issue-work [--task <id>]` and review the returned bundle (active tasks, recent journal, relevant wiki, skill health). Use these to inform your approach — prior failures, relevant patterns, and active tasks provide context the user may not have stated explicitly.
+
 ### 1. Detect issue source
 
 Determine whether we're working with GitHub or JIRA based on the input:

--- a/skills/geno-dev-prs-check/SKILL.md
+++ b/skills/geno-dev-prs-check/SKILL.md
@@ -104,3 +104,19 @@ If there are `CLOSEABLE` PRs, add:
 ### 6. Multi-repo output
 
 If `--all` was used, repeat steps 2–5 for each repo with an H2 header per repo. End with a combined summary across all repos.
+
+## Completion
+
+When this skill finishes, emit a trace:
+
+```bash
+geno-trace emit \
+  --skill geno-dev-prs-check \
+  --status <success|failure|abandoned> \
+  --tool-calls <approximate count> \
+  --errors <count of tool/command errors>
+```
+
+- `success` = PR status table rendered with classification tags and summary for all resolved repos
+- `failure` = no repos resolved, or gh CLI failed to fetch PR data
+- `abandoned` = user stopped early

--- a/skills/geno-dev-scheduling-snooze/SKILL.md
+++ b/skills/geno-dev-scheduling-snooze/SKILL.md
@@ -111,3 +111,19 @@ Report:
 - **Under 60 seconds**: ScheduleWakeup clamps to 60s minimum. Tell the user: "Minimum snooze is 60 seconds."
 - **Ambiguous time**: If the time expression is ambiguous (e.g., "3:30" without AM/PM), infer based on context — if it's currently 2 AM, "3:30" likely means 3:30 AM. If it's 2 PM, "3:30" likely means 3:30 PM. When uncertain, ask.
 - **No arguments**: Ask the user for a time expression.
+
+## Completion
+
+When this skill finishes, emit a trace:
+
+```bash
+geno-trace emit \
+  --skill geno-dev-scheduling-snooze \
+  --status <success|failure|abandoned> \
+  --tool-calls <approximate count> \
+  --errors <count of tool/command errors>
+```
+
+- `success` = ScheduleWakeup called with correct delay and prompt; confirmation displayed to user
+- `failure` = time expression unparseable, or ScheduleWakeup call failed
+- `abandoned` = user stopped early or declined to provide a wakeup prompt

--- a/skills/geno-dev-sessions-fork/SKILL.md
+++ b/skills/geno-dev-sessions-fork/SKILL.md
@@ -79,3 +79,19 @@ The fork output is a structured markdown document with these sections:
 - **Handoff** — pass session context to a different model or agent configuration
 - **Knowledge transfer** — share what a session accomplished with other agents or team members
 - **Debugging** — extract a full record of what happened in a session for analysis
+
+## Completion
+
+When this skill finishes, emit a trace:
+
+```bash
+geno-trace emit \
+  --skill geno-dev-sessions-fork \
+  --status <success|failure|abandoned> \
+  --tool-calls <approximate count> \
+  --errors <count of tool/command errors>
+```
+
+- `success` = session context extracted and delivered (displayed or written to file)
+- `failure` = geno-mon not found, fork command failed, or no sessions available
+- `abandoned` = user stopped early or declined to select a session

--- a/skills/geno-dev-sessions-remote/SKILL.md
+++ b/skills/geno-dev-sessions-remote/SKILL.md
@@ -71,3 +71,15 @@ Launch a Claude Code session with remote access enabled in a target workspace. O
 - The session name is passed to `--remote-control` and used to identify the session in the remote control UI.
 - Remote sessions can be accessed from any device via the URL printed in the Terminal.
 - To stop the session, close the Terminal window or press Ctrl+C.
+
+## Completion
+
+When this skill finishes, emit a trace:
+
+```bash
+geno-trace emit \
+  --skill geno-dev-sessions-remote \
+  --status <success|failure|abandoned> \
+  --tool-calls <approximate count> \
+  --errors <count of tool/command errors>
+```

--- a/skills/geno-dev-tasks-start/SKILL.md
+++ b/skills/geno-dev-tasks-start/SKILL.md
@@ -32,6 +32,10 @@ The user optionally provides a task description or number as `$ARGUMENTS`. If em
 
 ## Workflow
 
+### 0. Load knowledge context
+
+Run `geno-notes context --skill geno-dev-tasks-start [--task <id>]` and review the returned bundle (active tasks, recent journal, relevant wiki, skill health). Use these to inform your approach — prior failures, relevant patterns, and active tasks provide context the user may not have stated explicitly.
+
 ### 1. Load context
 
 - Read `geno-notes tasks` in the current working directory

--- a/skills/geno-dev-workspaces-init/SKILL.md
+++ b/skills/geno-dev-workspaces-init/SKILL.md
@@ -230,3 +230,15 @@ List all workspaces across all configured color folders.
 | `lottie-creator-ws` | code-purp | — | — | — | — | [unmanaged] |
 
 Sort: active workspaces first, then by creation date (newest first). Legacy and unmanaged at the end.
+
+## Completion
+
+When this skill finishes, emit a trace:
+
+```bash
+geno-trace emit \
+  --skill geno-dev-workspaces-init \
+  --status <success|failure|abandoned> \
+  --tool-calls <approximate count> \
+  --errors <count of tool/command errors>
+```

--- a/skills/geno-dev-worktrees-manage/SKILL.md
+++ b/skills/geno-dev-worktrees-manage/SKILL.md
@@ -133,3 +133,19 @@ Note: The agent cannot change the user's shell working directory. This subcomman
    - If the branch was merged, offer to delete it: `git branch -d <branch>`
 7. Run `git worktree prune` to clean up stale administrative files.
 8. Show summary of what was removed.
+
+## Completion
+
+When this skill finishes, emit a trace:
+
+```bash
+geno-trace emit \
+  --skill geno-dev-worktrees-manage \
+  --status <success|failure|abandoned> \
+  --tool-calls <approximate count> \
+  --errors <count of tool/command errors>
+```
+
+- `success` = subcommand completed (worktrees listed, created, located, or pruned as requested)
+- `failure` = not a git repo, worktree creation/removal failed, or safety violation encountered
+- `abandoned` = user cancelled prune operation or stopped early


### PR DESCRIPTION
## Summary

- Add Step 0 (knowledge context loading) to 5 pilot skills: turbocharge, cruise, tasks-start, feature-ship, issue-work
- Add trace completion sections to 12 skills missing them
- Add observability frontmatter to skills that lacked it

## Test plan

- [ ] Verify all 17 modified SKILL.md files parse correctly
- [ ] Invoke a pilot skill and confirm Step 0 runs `geno-notes context`
- [ ] Verify `geno-trace emit` works from completion sections